### PR TITLE
[Feat] MVI 패턴 적용된 BaseViewModel 구현

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/whatever/caramel/core/presentation/BaseViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/whatever/caramel/core/presentation/BaseViewModel.kt
@@ -1,0 +1,68 @@
+package com.whatever.caramel.core.presentation
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.whatever.caramel.core.domain.CaramelException
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+abstract class BaseViewModel<S : UiState, SE : UiSideEffect, I : UiIntent>(
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val initialState: S by lazy { createInitialState(savedStateHandle) }
+
+    protected abstract fun createInitialState(savedStateHandle: SavedStateHandle): S
+
+    protected abstract suspend fun handleIntent(intent: I)
+
+    private val _state = MutableStateFlow(initialState)
+    val state = _state.asStateFlow()
+
+    private val _sideEffect: MutableSharedFlow<SE> = MutableSharedFlow()
+    val sideEffect = _sideEffect.asSharedFlow()
+
+    protected val currentState: S
+        get() = _state.value
+
+    protected val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        handleClientException(throwable as CaramelException)
+    }
+
+    fun intent(intent: I) {
+        launch {
+            handleIntent(intent)
+        }
+    }
+
+    protected fun reduce(reduce: S.() -> S) {
+        val state = currentState.reduce()
+        _state.value = state
+    }
+
+    protected fun postSideEffect(sideEffect: SE) {
+        viewModelScope.launch { _sideEffect.emit(sideEffect) }
+    }
+
+    protected inline fun launch(
+        context: CoroutineContext = EmptyCoroutineContext,
+        start: CoroutineStart = CoroutineStart.DEFAULT,
+        crossinline action: suspend CoroutineScope.() -> Unit,
+    ): Job {
+        return viewModelScope.launch(context + coroutineExceptionHandler, start = start) {
+            action()
+        }
+    }
+
+    open fun handleClientException(throwable: CaramelException) {}
+}

--- a/composeApp/src/commonMain/kotlin/com/whatever/caramel/core/presentation/UiIntent.kt
+++ b/composeApp/src/commonMain/kotlin/com/whatever/caramel/core/presentation/UiIntent.kt
@@ -1,0 +1,3 @@
+package com.whatever.caramel.core.presentation
+
+interface UiIntent

--- a/composeApp/src/commonMain/kotlin/com/whatever/caramel/core/presentation/UiSideEffect.kt
+++ b/composeApp/src/commonMain/kotlin/com/whatever/caramel/core/presentation/UiSideEffect.kt
@@ -1,0 +1,3 @@
+package com.whatever.caramel.core.presentation
+
+interface UiSideEffect

--- a/composeApp/src/commonMain/kotlin/com/whatever/caramel/core/presentation/UiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/whatever/caramel/core/presentation/UiState.kt
@@ -1,0 +1,3 @@
+package com.whatever.caramel.core.presentation
+
+interface UiState

--- a/composeApp/src/commonMain/kotlin/com/whatever/caramel/feat/sample/presentation/SampleScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/whatever/caramel/feat/sample/presentation/SampleScreen.kt
@@ -2,13 +2,23 @@ package com.whatever.caramel.feat.sample.presentation
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.whatever.caramel.feat.sample.presentation.mvi.SampleIntent
+import com.whatever.caramel.feat.sample.presentation.mvi.SampleSideEffect
+import com.whatever.caramel.feat.sample.presentation.mvi.SampleUiState
+import io.github.aakira.napier.Napier
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -16,15 +26,43 @@ internal fun SampleRoute(
     viewModel: SampleViewModel = koinViewModel()
 ) {
     val uiState = viewModel.state.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(key1 = lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.getSampleData()
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                is SampleSideEffect.ShowSnackBar -> {
+                    // @ham2174 EX : 스낵바 호출, 네비게이션 이동 등 다른 사이드 이펙트 처리
+                    Napier.d { "스낵바 호출" }
+                }
+            }
+        }
+    }
 
     SampleScreen(
-        state = uiState.value
+        state = uiState.value,
+        onIntent = { intent -> viewModel.intent(intent)}
     )
 }
 
 @Composable
 private fun SampleScreen(
-    state: SampleUiState
+    state: SampleUiState,
+    onIntent: (SampleIntent) -> Unit
 ) {
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -35,5 +73,15 @@ private fun SampleScreen(
             fontSize = 12.sp,
             color = Color.Black
         )
+
+        Button(
+            modifier = Modifier
+                .align(Alignment.BottomCenter),
+            onClick = { onIntent(SampleIntent.ClickButton) }
+        ) {
+            Text(
+                text = "Intent 테스트 버튼"
+            )
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/whatever/caramel/feat/sample/presentation/SampleViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/whatever/caramel/feat/sample/presentation/SampleViewModel.kt
@@ -1,51 +1,38 @@
 package com.whatever.caramel.feat.sample.presentation
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.whatever.caramel.core.domain.CaramelException
-import com.whatever.caramel.core.domain.ErrorUiType
+import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.presentation.BaseViewModel
 import com.whatever.caramel.feat.sample.domain.SampleRepository
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-
-data class SampleUiState(
-    val text: String = ""
-)
+import com.whatever.caramel.feat.sample.presentation.mvi.SampleIntent
+import com.whatever.caramel.feat.sample.presentation.mvi.SampleSideEffect
+import com.whatever.caramel.feat.sample.presentation.mvi.SampleUiState
 
 class SampleViewModel(
-    private val sampleRepository: SampleRepository
-) : ViewModel() {
+    private val sampleRepository: SampleRepository,
+    savedStateHandle: SavedStateHandle
+) : BaseViewModel<SampleUiState, SampleSideEffect, SampleIntent>(savedStateHandle) {
 
-    private val _state: MutableStateFlow<SampleUiState> = MutableStateFlow(SampleUiState())
-    val state: StateFlow<SampleUiState> = _state.asStateFlow()
-
-    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        val exception = throwable as CaramelException
-        handleClientException(exception = exception)
+    override fun createInitialState(savedStateHandle: SavedStateHandle): SampleUiState {
+        return SampleUiState()
     }
 
-    init {
-        getSampleData()
-    }
-
-    private fun getSampleData() {
-        viewModelScope.launch(context = coroutineExceptionHandler) {
-            val sampleData = sampleRepository.getSampleData()
-
-            _state.update { uiState ->
-                uiState.copy(text = sampleData.toString())
+    override suspend fun handleIntent(intent: SampleIntent) {
+        when (intent) {
+            is SampleIntent.ClickButton -> {
+                postSideEffect(SampleSideEffect.ShowSnackBar)
             }
         }
     }
 
-    private fun handleClientException(exception: CaramelException) {
-        when (exception.errorUiType) {
-            ErrorUiType.SNACK_BAR -> { }
-            ErrorUiType.EMPTY_UI -> { }
+    fun getSampleData() {
+        launch {
+            val sampleData = sampleRepository.getSampleData()
+
+            reduce {
+                copy(
+                    text = sampleData.toString()
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/whatever/caramel/feat/sample/presentation/mvi/SampleIntent.kt
+++ b/composeApp/src/commonMain/kotlin/com/whatever/caramel/feat/sample/presentation/mvi/SampleIntent.kt
@@ -1,0 +1,9 @@
+package com.whatever.caramel.feat.sample.presentation.mvi
+
+import com.whatever.caramel.core.presentation.UiIntent
+
+sealed interface SampleIntent : UiIntent {
+
+    data object ClickButton : SampleIntent
+
+}

--- a/composeApp/src/commonMain/kotlin/com/whatever/caramel/feat/sample/presentation/mvi/SampleSideEffect.kt
+++ b/composeApp/src/commonMain/kotlin/com/whatever/caramel/feat/sample/presentation/mvi/SampleSideEffect.kt
@@ -1,0 +1,9 @@
+package com.whatever.caramel.feat.sample.presentation.mvi
+
+import com.whatever.caramel.core.presentation.UiSideEffect
+
+sealed interface SampleSideEffect : UiSideEffect {
+
+    data object ShowSnackBar : SampleSideEffect
+
+}

--- a/composeApp/src/commonMain/kotlin/com/whatever/caramel/feat/sample/presentation/mvi/SampleUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/whatever/caramel/feat/sample/presentation/mvi/SampleUiState.kt
@@ -1,0 +1,7 @@
+package com.whatever.caramel.feat.sample.presentation.mvi
+
+import com.whatever.caramel.core.presentation.UiState
+
+data class SampleUiState(
+    val text: String = ""
+) : UiState


### PR DESCRIPTION
## 관련 이슈
- closed #28 

## 작업한 내용
- BaseViewModel 구현
- 샘플 화면 및 샘플 뷰모델 구현

## PR 포인트
- 현재 화면에 해당하는 데이터 초기화 작업을 `ViewModel`의 `init` 블럭내부이 아닌, `Lifecycle`에 따라 초기화 하도록 구현하였습니다. 생명주기를 인식해야하는 경우가 아니라면 `ViewModel`의 `init` 블럭을 사용해서 데이터를 초기화 해도 괜찮을것 같습니다!
- `LocalLifecycleOwner`가 [**Compose1.7.*** 버전이후 Desktop, iOS 등 타플랫폼 생명주기를 인식](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-lifecycle.html)하도록 변경되었다고 해서 내부 코드를 들여다 보긴 했는데,,,, 사실이 맞는지  iOS 환경에서 테스트가 필요합니다! (샘플 화면에서 로직 구현완료..)
  - 변경된 `LocalLifecycleOwner`
  ![image](https://github.com/user-attachments/assets/5cfc9f28-b12e-4766-94cf-24297e0ed6bc)
  - Deprecate된 이전 `LocalLifecycleOwner`
  ![image](https://github.com/user-attachments/assets/4513d6d8-405c-430d-af86-48fd41ba3211)
  - iOS 환경에서 적용된 부분 (`ComposeUIViewController` 내부 구현체에서 확인 가능)
  ![image](https://github.com/user-attachments/assets/7ae71a66-58c5-4d34-8441-49c4da790311)
  ![image](https://github.com/user-attachments/assets/819499fd-cfbd-4ae2-b13a-aad10c23e218)


