### PR TITLE
[Feat] iOS 플랫폼 Apple 로그인 구현

### DIFF
--- a/app-ios/iosApp.xcodeproj/project.pbxproj
+++ b/app-ios/iosApp.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		BA981A902D6B7F0000F4630B /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		BA981A922D6B7F0A00F4630B /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		E94D125F2D7A3F4E00262C39 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		E96349E22D7C238E00F6BBF7 /* iosApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iosApp.entitlements; sourceTree = "<group>"; };
 		E9A293E92D78E4930060A927 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -92,6 +93,7 @@
 		7555FF7D242A565900829871 /* iosApp */ = {
 			isa = PBXGroup;
 			children = (
+				E96349E22D7C238E00F6BBF7 /* iosApp.entitlements */,
 				BA981A8F2D6B7EEA00F4630B /* Configuration */,
 				058557BA273AAA24004C7B11 /* Assets.xcassets */,
 				7555FF82242A565900829871 /* ContentView.swift */,
@@ -378,8 +380,12 @@
 			baseConfigurationReference = BA981A902D6B7F0000F4630B /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AR6HWFH5V3;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -399,6 +405,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.whatever.caramel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Caramel Provisioning - Development";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -409,8 +417,12 @@
 			baseConfigurationReference = BA981A922D6B7F0A00F4630B /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AR6HWFH5V3;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -430,6 +442,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.whatever.caramel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Caramel Provisioning - Deistribution";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/app-ios/iosApp/iosApp.entitlements
+++ b/app-ios/iosApp/iosApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/feature/login/src/androidMain/kotlin/com/whatever/caramel/feature/login/di/Module.android.kt
+++ b/feature/login/src/androidMain/kotlin/com/whatever/caramel/feature/login/di/Module.android.kt
@@ -1,6 +1,6 @@
 package com.whatever.caramel.feature.login.di
 
-import com.whatever.caramel.feature.login.social.KakaoAuthProviderImpl
+import com.whatever.caramel.feature.login.social.kakao.KakaoAuthProviderImpl
 import com.whatever.caramel.feature.login.social.kakao.KakaoAuthProvider
 import org.koin.core.module.Module
 import org.koin.dsl.module

--- a/feature/login/src/androidMain/kotlin/com/whatever/caramel/feature/login/social/kakao/KakaoAuthProviderImpl.kt
+++ b/feature/login/src/androidMain/kotlin/com/whatever/caramel/feature/login/social/kakao/KakaoAuthProviderImpl.kt
@@ -1,4 +1,4 @@
-package com.whatever.caramel.feature.login.social
+package com.whatever.caramel.feature.login.social.kakao
 
 import android.content.Context
 import androidx.compose.runtime.Composable
@@ -9,8 +9,8 @@ import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
 import com.whatever.caramel.feature.login.BuildConfig
-import com.whatever.caramel.feature.login.social.kakao.KakaoAuthProvider
-import com.whatever.caramel.feature.login.social.kakao.KakaoUser
+import com.whatever.caramel.feature.login.social.SocialAuthResult
+import com.whatever.caramel.feature.login.social.SocialAuthenticator
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume

--- a/feature/login/src/androidMain/kotlin/com/whatever/caramel/feature/login/util/Platform.android.kt
+++ b/feature/login/src/androidMain/kotlin/com/whatever/caramel/feature/login/util/Platform.android.kt
@@ -1,0 +1,5 @@
+package com.whatever.caramel.feature.login.util
+
+actual object Platform {
+    actual val isIos: Boolean = false
+}

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginRoute.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginRoute.kt
@@ -9,7 +9,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.whatever.caramel.feature.login.mvi.LoginIntent
 import com.whatever.caramel.feature.login.mvi.LoginSideEffect
 import com.whatever.caramel.feature.login.mvi.SocialAuthType
+import com.whatever.caramel.feature.login.social.SocialAuthenticator
+import com.whatever.caramel.feature.login.social.apple.AppleAuthProvider
+import com.whatever.caramel.feature.login.social.apple.AppleUser
 import com.whatever.caramel.feature.login.social.kakao.KakaoAuthProvider
+import com.whatever.caramel.feature.login.social.kakao.KakaoUser
+import com.whatever.caramel.feature.login.util.Platform
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -17,14 +22,13 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 internal fun LoginRoute(
     viewModel: LoginViewModel = koinViewModel(),
+    kakaoAuthenticator: SocialAuthenticator<KakaoUser> = koinInject<KakaoAuthProvider>().get(),
+    appleAuthenticator: SocialAuthenticator<AppleUser>? = if (Platform.isIos) koinInject<AppleAuthProvider>().get() else null,
     navigateToCreateProfile: () -> Unit,
     navigateToConnectCouple: () -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-
     val scope = rememberCoroutineScope()
-    val kakaoAuthenticator = koinInject<KakaoAuthProvider>().get()
-
     val socialAuthLaunch: (SocialAuthType) -> Unit = remember {
         { type ->
             scope.launch {
@@ -35,7 +39,8 @@ internal fun LoginRoute(
                     }
 
                     SocialAuthType.APPLE -> {
-
+                        val result = appleAuthenticator!!.authenticate()
+                        viewModel.intent(LoginIntent.ClickAppleLoginButton(result = result))
                     }
                 }
             }

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.sp
 import com.whatever.caramel.feature.login.mvi.LoginIntent
 import com.whatever.caramel.feature.login.mvi.LoginState
 import com.whatever.caramel.feature.login.mvi.SocialAuthType
+import com.whatever.caramel.feature.login.util.Platform
 
 @Composable
 internal fun LoginScreen(
@@ -48,15 +49,17 @@ internal fun LoginScreen(
                 )
             }
 
-            Button(
-                modifier = Modifier
-                    .fillMaxWidth(),
-                onClick = { onLaunch(SocialAuthType.KAKAO) }
-            ) {
-                Text(
-                    text = "애플 로그인 (커플 연결)",
-                    fontSize = 18.sp
-                )
+            if (Platform.isIos) {
+                Button(
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    onClick = { onLaunch(SocialAuthType.APPLE) }
+                ) {
+                    Text(
+                        text = "애플 로그인 (커플 연결)",
+                        fontSize = 18.sp
+                    )
+                }
             }
         }
     }

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginViewModel.kt
@@ -8,8 +8,14 @@ import com.whatever.caramel.feature.login.mvi.LoginIntent
 import com.whatever.caramel.feature.login.mvi.LoginSideEffect
 import com.whatever.caramel.feature.login.mvi.LoginState
 import com.whatever.caramel.feature.login.social.SocialAuthResult
+import com.whatever.caramel.feature.login.social.apple.AppleUser
 import com.whatever.caramel.feature.login.social.kakao.KakaoUser
 import io.github.aakira.napier.Napier
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
 class LoginViewModel(
     savedStateHandle: SavedStateHandle,
@@ -23,6 +29,7 @@ class LoginViewModel(
     override suspend fun handleIntent(intent: LoginIntent) {
         when (intent) {
             is LoginIntent.ClickKakaoLoginButton -> kakaoLogin(result = intent.result)
+            is LoginIntent.ClickAppleLoginButton -> appleLogin(result = intent.result)
         }
     }
 
@@ -48,6 +55,21 @@ class LoginViewModel(
             }
             is SocialAuthResult.UserCancelled -> {
                 // 사용자 취소
+                Napier.d { "사용자 취소" }
+            }
+        }
+    }
+
+    private fun appleLogin(result: SocialAuthResult<AppleUser>) {
+        when (result) {
+            is SocialAuthResult.Success -> {
+                Napier.d { "성공" }
+                Napier.d { result.data.idToken }
+            }
+            is SocialAuthResult.Error -> {
+                Napier.d { "에러" }
+            }
+            is SocialAuthResult.UserCancelled -> {
                 Napier.d { "사용자 취소" }
             }
         }

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/mvi/LoginIntent.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/mvi/LoginIntent.kt
@@ -2,10 +2,13 @@ package com.whatever.caramel.feature.login.mvi
 
 import com.whatever.caramel.core.viewmodel.UiIntent
 import com.whatever.caramel.feature.login.social.SocialAuthResult
+import com.whatever.caramel.feature.login.social.apple.AppleUser
 import com.whatever.caramel.feature.login.social.kakao.KakaoUser
 
 sealed interface LoginIntent : UiIntent {
 
     data class ClickKakaoLoginButton(val result: SocialAuthResult<KakaoUser>) : LoginIntent
+
+    data class ClickAppleLoginButton(val result: SocialAuthResult<AppleUser>) : LoginIntent
 
 }

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/social/apple/AppleAuthenticator.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/social/apple/AppleAuthenticator.kt
@@ -1,0 +1,5 @@
+package com.whatever.caramel.feature.login.social.apple
+
+import com.whatever.caramel.feature.login.social.SocialAuthProvider
+
+interface AppleAuthProvider : SocialAuthProvider<AppleUser>

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/social/apple/AppleUser.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/social/apple/AppleUser.kt
@@ -1,0 +1,5 @@
+package com.whatever.caramel.feature.login.social.apple
+
+data class AppleUser(
+    val idToken: String
+)

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/util/Platform.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/util/Platform.kt
@@ -1,0 +1,5 @@
+package com.whatever.caramel.feature.login.util
+
+expect object Platform {
+    val isIos: Boolean
+}

--- a/feature/login/src/iosMain/kotlin/com/whatever/caramel/feature/login/di/Module.ios.kt
+++ b/feature/login/src/iosMain/kotlin/com/whatever/caramel/feature/login/di/Module.ios.kt
@@ -1,8 +1,8 @@
 package com.whatever.caramel.feature.login.di
 
-import com.whatever.caramel.feature.login.social.KakaoAuthProviderImpl
 import com.whatever.caramel.feature.login.social.apple.AppleAuthProvider
 import com.whatever.caramel.feature.login.social.apple.AppleAuthProviderImpl
+import com.whatever.caramel.feature.login.social.kakao.KakaoAuthProviderImpl
 import com.whatever.caramel.feature.login.social.kakao.KakaoAuthProvider
 import kotlinx.cinterop.ExperimentalForeignApi
 import org.koin.core.module.Module
@@ -12,10 +12,6 @@ import swiftBridge.KakaoLoginBridge
 @OptIn(ExperimentalForeignApi::class)
 actual val socialModule: Module
     get() = module {
-        factory<KakaoAuthProvider> {
-            KakaoAuthProviderImpl(
-                bridge = KakaoLoginBridge()
-            )
-        }
+        factory<KakaoAuthProvider> { KakaoAuthProviderImpl(bridge = KakaoLoginBridge()) }
         factory<AppleAuthProvider> { AppleAuthProviderImpl() }
     }

--- a/feature/login/src/iosMain/kotlin/com/whatever/caramel/feature/login/di/Module.ios.kt
+++ b/feature/login/src/iosMain/kotlin/com/whatever/caramel/feature/login/di/Module.ios.kt
@@ -1,6 +1,8 @@
 package com.whatever.caramel.feature.login.di
 
 import com.whatever.caramel.feature.login.social.KakaoAuthProviderImpl
+import com.whatever.caramel.feature.login.social.apple.AppleAuthProvider
+import com.whatever.caramel.feature.login.social.apple.AppleAuthProviderImpl
 import com.whatever.caramel.feature.login.social.kakao.KakaoAuthProvider
 import kotlinx.cinterop.ExperimentalForeignApi
 import org.koin.core.module.Module
@@ -15,4 +17,5 @@ actual val socialModule: Module
                 bridge = KakaoLoginBridge()
             )
         }
+        factory<AppleAuthProvider> { AppleAuthProviderImpl() }
     }

--- a/feature/login/src/iosMain/kotlin/com/whatever/caramel/feature/login/social/apple/AppleAuthProviderImpl.kt
+++ b/feature/login/src/iosMain/kotlin/com/whatever/caramel/feature/login/social/apple/AppleAuthProviderImpl.kt
@@ -1,0 +1,100 @@
+package com.whatever.caramel.feature.login.social.apple
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.uikit.LocalUIViewController
+import com.whatever.caramel.feature.login.social.SocialAuthResult
+import com.whatever.caramel.feature.login.social.SocialAuthenticator
+import kotlinx.cinterop.BetaInteropApi
+import platform.AuthenticationServices.ASAuthorization
+import platform.AuthenticationServices.ASAuthorizationAppleIDCredential
+import platform.AuthenticationServices.ASAuthorizationAppleIDProvider
+import platform.AuthenticationServices.ASAuthorizationController
+import platform.AuthenticationServices.ASAuthorizationControllerDelegateProtocol
+import platform.AuthenticationServices.ASAuthorizationControllerPresentationContextProvidingProtocol
+import platform.AuthenticationServices.ASAuthorizationScopeEmail
+import platform.AuthenticationServices.ASAuthorizationScopeFullName
+import platform.AuthenticationServices.ASPresentationAnchor
+import platform.Foundation.NSError
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.create
+import platform.UIKit.UIViewController
+import platform.darwin.NSObject
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+internal class AppleAuthProviderImpl : AppleAuthProvider {
+
+    @Composable
+    override fun get(): SocialAuthenticator<AppleUser> {
+        val viewController = LocalUIViewController.current
+        return AppleAuthenticatorImpl(viewController = viewController)
+    }
+
+}
+
+/**
+ * Swift에 정의된 인증 실패시 발생 되는 에러 코드 [공식문서](https://developer.apple.com/documentation/authenticationservices/asauthorizationerror-swift.struct/code)
+ * @author GunHyung-Ham
+ * @since 2025.03.09
+ */
+enum class ASAuthorizationErrorCode(val code: Int) {
+    FAILED(1000),
+    CANCELED(1001),
+    NOT_HANDLED(1002),
+    INVALID_RESPONSE(1003),
+    NOT_INTERACTIVE(1004),
+    UNKNOWN(1005),
+    CREDENTIAL_EXPORT(1006),
+    CREDENTIAL_IMPORT(1007),
+    ;
+}
+
+private class AppleAuthenticatorImpl(
+    private val viewController: UIViewController
+) : SocialAuthenticator<AppleUser> {
+
+    @OptIn(BetaInteropApi::class)
+    override suspend fun authenticate(): SocialAuthResult<AppleUser> =
+        suspendCoroutine { continuation ->
+            val provider = ASAuthorizationAppleIDProvider()
+            val request = provider.createRequest()
+            request.requestedScopes = listOf(ASAuthorizationScopeFullName, ASAuthorizationScopeEmail)
+            val controller = ASAuthorizationController(listOf(request))
+
+            controller.delegate = object : NSObject(), ASAuthorizationControllerDelegateProtocol {
+                override fun authorizationController(
+                    controller: ASAuthorizationController,
+                    didCompleteWithAuthorization: ASAuthorization
+                ) {
+                    val credential = didCompleteWithAuthorization.credential as? ASAuthorizationAppleIDCredential
+                    val idToken = credential?.identityToken?.let { data ->
+                        NSString.create(data, NSUTF8StringEncoding)?.toString()
+                    }
+
+                    continuation.resume(SocialAuthResult.Success(AppleUser(idToken = idToken!!)))
+                }
+
+                override fun authorizationController(
+                    controller: ASAuthorizationController,
+                    didCompleteWithError: NSError
+                ) {
+                    val errorCode = didCompleteWithError.code.toInt()
+                    val socialAuthResult = when (errorCode) {
+                        ASAuthorizationErrorCode.CANCELED.code -> SocialAuthResult.UserCancelled
+                        else -> SocialAuthResult.Error
+                    }
+
+                    continuation.resume(socialAuthResult)
+                }
+            }
+
+            controller.presentationContextProvider = object : NSObject(), ASAuthorizationControllerPresentationContextProvidingProtocol {
+                override fun presentationAnchorForAuthorizationController(controller: ASAuthorizationController): ASPresentationAnchor =
+                    viewController.view.window
+            }
+
+            controller.performRequests()
+        }
+
+}

--- a/feature/login/src/iosMain/kotlin/com/whatever/caramel/feature/login/social/kakao/KakaoAuthProviderImpl.kt
+++ b/feature/login/src/iosMain/kotlin/com/whatever/caramel/feature/login/social/kakao/KakaoAuthProviderImpl.kt
@@ -1,8 +1,8 @@
-package com.whatever.caramel.feature.login.social
+package com.whatever.caramel.feature.login.social.kakao
 
 import androidx.compose.runtime.Composable
-import com.whatever.caramel.feature.login.social.kakao.KakaoAuthProvider
-import com.whatever.caramel.feature.login.social.kakao.KakaoUser
+import com.whatever.caramel.feature.login.social.SocialAuthResult
+import com.whatever.caramel.feature.login.social.SocialAuthenticator
 import kotlinx.cinterop.ExperimentalForeignApi
 import swiftBridge.KakaoLoginBridge
 import kotlin.coroutines.resume

--- a/feature/login/src/iosMain/kotlin/com/whatever/caramel/feature/login/util/Platform.ios.kt
+++ b/feature/login/src/iosMain/kotlin/com/whatever/caramel/feature/login/util/Platform.ios.kt
@@ -1,0 +1,5 @@
+package com.whatever.caramel.feature.login.util
+
+actual object Platform {
+    actual val isIos: Boolean = true
+}


### PR DESCRIPTION
## 관련 이슈
- closed #43 

## 작업한 내용
- iOS Apple 인증 로직 구현

## PR 포인트
### Apple Auth
- 애플 인증 기능이 iOS의 Native API에서 제공되는 기능들이라 KMP 환경에서도 그대로 쓸수 있었습니다. 다만, 몇몇 클래스들은 Kotlin으로 변환을 해주어야 하는 작업을 요구합니다. (예시로 NSData 타입인 `identityToken` 은 코틀린에서 사용할 수있는 타입이 아니기에 String으로 변환해주기 위한 작업을 요구합니다.)
- [iOS 애플 로그인 참고 자료](https://haram22.tistory.com/74)

### 로그인 실패 시 예외 처리
- 로그인 실패시 사용자 취소 에러와 애플 서버측 에러를 콜백으로 `NSError` 객체를 받고 있습니다
- [애플 공식문서](https://developer.apple.com/documentation/authenticationservices/asauthorizationerror-swift.struct/code)에 따르면 인증 에러 코드 중 `canceled`이 사용자 취소 에러 코드이며 나머지는 애플서버 에러 혹은 인증서 관련 에러로 안내하고 있습니다.
- KMP 환경에서 Native Enum Class인 ASAuthorizationErrorCode를 직접 사용할 수 없어 아래와 같이 Kotlin으로 직접 Enum Class로 정의하고 에러 코드에 따른 예외 처리를 할수 있습니다.
<img src="https://github.com/user-attachments/assets/baa41294-6682-417b-92b2-7e0a46813aee" width=300 height=250/>

```
...
override fun authorizationController(
                    controller: ASAuthorizationController,
                    didCompleteWithError: NSError
                ) {
                    val errorCode = didCompleteWithError.code.toInt()
                    val socialAuthResult = when (errorCode) {
                        ASAuthorizationErrorCode.CANCELED.code -> SocialAuthResult.UserCancelled
                        else -> SocialAuthResult.Error
                    }

                    continuation.resume(socialAuthResult)
                }
...
```

### 플랫폼 별 AppleAuthProvider DI 분기
- Android 에서는 애플 로그인 기능이 제외되므로 AppleAuthProvider DI도 플랫폼에 따라 분기처리 하여 생성해주고 있습니다.
- 애플 로그인 버튼 또한 플랫폼에 따라 나타납니다.
