### PR TITLE
[Fix] HttpResponseExtension 로직 오류

### DIFF
--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/network/config/CaramelResponseValidator.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/network/config/CaramelResponseValidator.kt
@@ -34,12 +34,6 @@ internal fun HttpClientConfig<*>.caramelResponseValidator() {
                     baseResponse.error.debugMessage,
                     baseResponse.error.message
                 )
-            } else {
-                throw CaramelNetworkException(
-                    "NETWORK_UNKNOWN",
-                    "Unknown network error",
-                    exception.message ?: "Unknown network error"
-                )
             }
         }
     }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/network/config/CaramelResponseValidator.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/network/config/CaramelResponseValidator.kt
@@ -11,30 +11,36 @@ import io.ktor.client.plugins.ResponseException
 internal fun HttpClientConfig<*>.caramelResponseValidator() {
     install(HttpCallValidator) {
         handleResponseExceptionWithRequest { exception, _ ->
-            val clientException = exception as ResponseException
-            val exceptionResponse = clientException.response
-            val baseResponse =
-                try {
-                    exceptionResponse.body<BaseResponse<Unit>>()
-                } catch (e: Exception) {
-                    BaseResponse<Unit>(
-                        success = false,
-                        data = null,
-                        error = ErrorResponse(
-                            code = clientException.response.status.value.toString(),
-                            message = "예상치 못한 에러 발생",
-                            debugMessage =
-                                "Error Code : ${clientException.response.status}\n"
-                                        + "Error Message : ${clientException.message}",
+            if (exception is ResponseException) {
+                val exceptionResponse = exception.response
+                val baseResponse =
+                    try {
+                        exceptionResponse.body<BaseResponse<Unit>>()
+                    } catch (e: Exception) {
+                        BaseResponse<Unit>(
+                            success = false,
+                            data = null,
+                            error = ErrorResponse(
+                                code = exception.response.status.value.toString(),
+                                message = "예상치 못한 에러 발생",
+                                debugMessage =
+                                    "Error Code : ${exception.response.status}\n"
+                                            + "Error Message : ${exception.message}",
+                            )
                         )
-                    )
-                }
-
-            throw CaramelNetworkException(
-                baseResponse.error?.code!!,
-                baseResponse.error.debugMessage,
-                baseResponse.error.message
-            )
+                    }
+                throw CaramelNetworkException(
+                    baseResponse.error?.code!!,
+                    baseResponse.error.debugMessage,
+                    baseResponse.error.message
+                )
+            } else {
+                throw CaramelNetworkException(
+                    "NETWORK_UNKNOWN",
+                    "Unknown network error",
+                    exception.message ?: "Unknown network error"
+                )
+            }
         }
     }
 }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/network/util/HttpResponseExtension.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/network/util/HttpResponseExtension.kt
@@ -5,11 +5,23 @@ import com.whatever.caramel.core.remote.network.exception.CaramelNetworkExceptio
 import io.ktor.client.call.body
 import io.ktor.client.statement.HttpResponse
 
+/**
+ * API 통신 시 발생하는 오류에 대한 예외처리
+ * @return API에 대한 DTO, DTO가 Unit, Response가 null인 경우 Unit을 return
+ * @throws CaramelNetworkException API 통신은 성공했으나 서버에서 오류가 나온 경우
+ * */
 suspend inline fun <reified T> HttpResponse.getBody(): T {
     val baseResponse = this.body<BaseResponse<T>>()
-
-    if (baseResponse.success && baseResponse.data != null) {
-        return baseResponse.data
+    if (baseResponse.success) {
+        return baseResponse.data ?: if(T::class == Unit::class){
+            Unit as T
+        } else {
+            throw CaramelNetworkException(
+                code = "Unknown",
+                message = "Data is null",
+                debugMessage = "Data is null"
+            )
+        }
     } else {
         if (baseResponse.error != null) {
             throw baseResponse.error.toException()


### PR DESCRIPTION
## 관련 이슈
- #56 

## 작업한 내용
- `getBody()`에서 API 호출 성공, Response의 data가 null인 경우 타입 캐스팅
- `caramelResponseValidator()`에서 BaseResponse 형변환 가능 확인에 따른 분기처리

## PR 포인트
### BaseResponse 강제 형변환
![image](https://github.com/user-attachments/assets/94d8c4e4-a489-4f3b-80d8-c8df2642d33d)
 `val clientException = exception as ResponseException`이 서버에 접근이 성공한 경우에만 Type 캐스팅이 되는 것 같습니다.

`getBody()`의 null 테스트 중에 http로 된 URL이 있었습니다. 현재  `usesCleartextTraffic`설정이 default로 `true`여서 `java.net.UnknownServiceException` 오류가 발생합니다.

`caramelResponseValidator()`에서 해당 부분을 잡을 때 형변환에 실패하면 위의 예외 클래스가 아닌 `ClassCastException`이 발생하여 어떤 예외가 발생했는지 확인이 어렵습니다.

따라서 Type 캐스팅이 가능한 경우와 아닌 경우로 나눠서 구현했습니다.