### PR TITLE
[Feat] 디자인 시스템 - WheelPicker 컴포넌트 구현

### DIFF
--- a/app/src/androidMain/AndroidManifest.xml
+++ b/app/src/androidMain/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
         android:name="com.whatever.caramel.GlobalApplication"

--- a/app/src/commonMain/kotlin/com/whatever/caramel/di/initKoin.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/di/initKoin.kt
@@ -6,6 +6,7 @@ import com.whatever.caramel.core.database.di.databaseModule
 import com.whatever.caramel.core.database.di.platformDatabaseModule
 import com.whatever.caramel.core.datastore.di.dataStoreModule
 import com.whatever.caramel.core.datastore.di.platformDataStoreModule
+import com.whatever.caramel.core.designsystem.di.hapticControllerModule
 import com.whatever.caramel.core.domain.di.useCaseModule
 import com.whatever.caramel.core.remote.di.networkClientEngineModule
 import com.whatever.caramel.core.remote.di.networkModule
@@ -51,6 +52,11 @@ fun initKoin(config: KoinAppDeclaration? = null) {
             useCaseModule,
 
             /* ==== Presentation Layer ==== */
+
+            /* DesignSystem Module */
+            hapticControllerModule,
+
+            /* Feature Module */
             calendarFeatureModule,
             contentFeatureModule,
             coupleConnectFeatureModule,

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.whatever.caramel.buildlogic.convention.extension.kotlin
+
 plugins {
     id("caramel.kmp")
     id("caramel.kmp.android")
@@ -6,3 +8,12 @@ plugins {
 }
 
 android.namespace = "com.whatever.caramel.core.designsystem"
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.koin.core)
+            implementation(libs.koin.compose)
+        }
+    }
+}

--- a/core/designsystem/src/androidMain/kotlin/com/whatever/caramel/core/designsystem/PickerPreview.kt
+++ b/core/designsystem/src/androidMain/kotlin/com/whatever/caramel/core/designsystem/PickerPreview.kt
@@ -1,0 +1,36 @@
+package com.whatever.caramel.core.designsystem
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.whatever.caramel.core.designsystem.components.CaramelTextWheelPicker
+import com.whatever.caramel.core.designsystem.components.PickerScrollMode
+import com.whatever.caramel.core.designsystem.components.rememberPickerState
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+
+@Preview(showBackground = true)
+@Composable
+private fun CaramelWheelPickerPreview() {
+    CaramelTheme {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            val items = List(1002) { it.toString() }
+
+            CaramelTextWheelPicker(
+                modifier = Modifier.width(50.dp),
+                items = items,
+                itemSpacing = 8.dp,
+                state = rememberPickerState(items),
+                scrollMode = PickerScrollMode.LOOPING,
+                onHapticFeedback = { }
+            )
+        }
+    }
+}

--- a/core/designsystem/src/androidMain/kotlin/com/whatever/caramel/core/designsystem/di/Modules.android.kt
+++ b/core/designsystem/src/androidMain/kotlin/com/whatever/caramel/core/designsystem/di/Modules.android.kt
@@ -1,0 +1,10 @@
+package com.whatever.caramel.core.designsystem.di
+
+import com.whatever.caramel.core.designsystem.util.AndroidHapticController
+import com.whatever.caramel.core.designsystem.util.HapticController
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val hapticControllerModule: Module = module {
+    single<HapticController> { AndroidHapticController(context = get()) }
+}

--- a/core/designsystem/src/androidMain/kotlin/com/whatever/caramel/core/designsystem/util/HapticController.android.kt
+++ b/core/designsystem/src/androidMain/kotlin/com/whatever/caramel/core/designsystem/util/HapticController.android.kt
@@ -1,0 +1,35 @@
+package com.whatever.caramel.core.designsystem.util
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+
+class AndroidHapticController(private val context: Context) : HapticController {
+
+    @SuppressLint("MissingPermission")
+    override fun performImpact(style: HapticStyle) {
+        val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val manager = context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+            manager.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        }
+
+        val duration = when (style) {
+            HapticStyle.GestureThresholdActivate -> 10L
+        }
+
+        val amplitude = when (style) {
+            HapticStyle.GestureThresholdActivate -> 30
+        }
+
+        vibrator.vibrate(
+            VibrationEffect.createOneShot(duration, amplitude)
+        )
+    }
+
+}

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Picker.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Picker.kt
@@ -63,7 +63,6 @@ enum class PickerScrollMode {
  * @param visibleItemsCount 화면에 동시에 보여질 아이템 개수입니다.
  * @param itemSpacing 아이템 간의 간격입니다.
  * @param textStyle 선택되지 않은 아이템에 적용할 [TextStyle]입니다.
- * @param dividerThickness 선택된 아이템 위아래에 그려지는 구분선의 두께입니다.
  * @param dividerColor Divider의 색상입니다.
  * @param scrollMode 피커의 스크롤 동작 모드입니다.
  * @param onHapticFeedback 아이템 변경 시 실행되는 햅틱 피드백 콜백입니다. [HapticController]를 주입받아 사용합니다.

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Picker.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Picker.kt
@@ -1,0 +1,210 @@
+package com.whatever.caramel.core.designsystem.components
+
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.whatever.caramel.core.designsystem.components.PickerScrollMode.BOUNDED
+import com.whatever.caramel.core.designsystem.components.PickerScrollMode.LOOPING
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.core.designsystem.util.HapticController
+import com.whatever.caramel.core.designsystem.util.HapticStyle
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
+import kotlin.math.abs
+
+@Composable
+fun <T> rememberPickerState(initialItem: T) = remember { PickerState(initialItem) }
+
+class PickerState<T>(
+    initialItem: T
+) {
+    var selectedItem by mutableStateOf(initialItem)
+}
+
+/**
+ * @property [LOOPING] 반복 스크롤 모드
+ * @property [BOUNDED] 시작-끝 스크롤 모드
+ * @author GunHyung-Ham
+ * @since 2025.04.02
+ */
+enum class PickerScrollMode {
+    LOOPING,
+    BOUNDED
+}
+
+/**
+ * @param modifier CaramelTextWheelPicker에 적용되는 Modifier 입니다.
+ * @param items 피커에 표시할 항목 목록입니다.
+ * @param state 선택된 아이템을 저장하고 외부와 공유할 [PickerState]입니다.
+ * @param startIndex 초기 선택 인덱스입니다.
+ * @param visibleItemsCount 화면에 동시에 보여질 아이템 개수입니다.
+ * @param itemSpacing 아이템 간의 간격입니다.
+ * @param textStyle 선택되지 않은 아이템에 적용할 [TextStyle]입니다.
+ * @param dividerThickness 선택된 아이템 위아래에 그려지는 구분선의 두께입니다.
+ * @param dividerColor Divider의 색상입니다.
+ * @param scrollMode 피커의 스크롤 동작 모드입니다.
+ * @param onHapticFeedback 아이템 변경 시 실행되는 햅틱 피드백 콜백입니다. [HapticController]를 주입받아 사용합니다.
+ *
+ * @author GunHyung-Ham
+ * @since 2025.04.02
+ */
+@Composable
+fun <T> CaramelTextWheelPicker(
+    modifier: Modifier = Modifier,
+    items: List<T>,
+    state: PickerState<T>,
+    startIndex: Int = 0,
+    visibleItemsCount: Int = 3,
+    itemSpacing: Dp = 8.dp,
+    textStyle: TextStyle = CaramelTheme.typography.heading2,
+    dividerColor: Color = CaramelTheme.color.fill.quaternary,
+    scrollMode: PickerScrollMode = LOOPING,
+    onHapticFeedback: (HapticStyle) -> Unit,
+) {
+    val visibleItemsMiddle = remember { visibleItemsCount / 2 }
+    val adjustedItems = when (scrollMode) {
+        LOOPING -> items
+        BOUNDED -> listOf(null) + items + listOf(null)
+    }
+
+    val listScrollCount = when (scrollMode) {
+        LOOPING -> Int.MAX_VALUE
+        BOUNDED -> adjustedItems.size
+    }
+
+    val listScrollMiddle = remember { listScrollCount / 2 }
+    val listStartIndex = remember {
+        when (scrollMode) {
+            LOOPING -> listScrollMiddle - listScrollMiddle % adjustedItems.size - visibleItemsMiddle + startIndex
+            BOUNDED -> startIndex + 1
+        }
+    }
+
+    val listState = rememberLazyListState(initialFirstVisibleItemIndex = listStartIndex)
+    val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+
+    fun getItem(index: Int) = adjustedItems[index % adjustedItems.size]
+
+    val selectedItemIndex by remember {
+        derivedStateOf {
+            val center = listState.layoutInfo.viewportStartOffset +
+                    (listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset) / 2
+
+            listState.layoutInfo.visibleItemsInfo.minByOrNull { item ->
+                val itemCenter = item.offset + item.size / 2
+                abs(itemCenter - center)
+            }?.index ?: 0
+        }
+    }
+
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.firstVisibleItemIndex }
+            .mapNotNull { index -> getItem(index + visibleItemsMiddle) }
+            .distinctUntilChanged()
+            .collect { item ->
+                onHapticFeedback(HapticStyle.GestureThresholdActivate)
+                state.selectedItem = item
+            }
+    }
+
+    SubcomposeLayout(modifier = modifier) { constraints ->
+        val itemPlaceable = subcompose("item") {
+            Text(
+                text = items.firstOrNull()?.toString().orEmpty(),
+                style = textStyle,
+            )
+        }.first().measure(constraints)
+
+        val itemHeight = itemPlaceable.measuredHeight.toDp()
+        val dividerThickness = 2.dp
+        val lazyColumnHeight =
+            (itemHeight * visibleItemsCount) + ((itemSpacing + dividerThickness) * (visibleItemsCount - 1))
+
+        val lazyColumnPlaceable = subcompose("list") {
+            Box(contentAlignment = Alignment.Center) {
+                LazyColumn(
+                    modifier = Modifier.height(height = lazyColumnHeight),
+                    state = listState,
+                    flingBehavior = flingBehavior,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(
+                        space = itemSpacing + dividerThickness
+                    ),
+                ) {
+                    items(
+                        count = listScrollCount,
+                        key = { it },
+                    ) { index ->
+                        val currentItemText by remember {
+                            mutableStateOf(if (getItem(index) == null) "" else getItem(index).toString())
+                        }
+
+                        Text(
+                            text = currentItemText,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            style = textStyle,
+                            textAlign = TextAlign.Center,
+                            color = if (index == selectedItemIndex) {
+                                CaramelTheme.color.text.primary
+                            } else {
+                                CaramelTheme.color.text.tertiary
+                            },
+                        )
+                    }
+                }
+
+                Box(
+                    modifier = Modifier
+                        .align(alignment = Alignment.Center)
+                        .height(height = itemHeight + itemSpacing + dividerThickness)
+                ) {
+                    // Top-Divider
+                    HorizontalDivider(
+                        color = dividerColor,
+                        thickness = dividerThickness,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .align(alignment = Alignment.TopCenter)
+                    )
+
+                    // Bottom-Divider
+                    HorizontalDivider(
+                        color = dividerColor,
+                        thickness = dividerThickness,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .align(alignment = Alignment.BottomCenter)
+                    )
+                }
+            }
+        }.first().measure(constraints)
+
+        layout(lazyColumnPlaceable.width, lazyColumnPlaceable.height) {
+            lazyColumnPlaceable.placeRelative(0, 0)
+        }
+    }
+}

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/di/Modules.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/di/Modules.kt
@@ -1,0 +1,5 @@
+package com.whatever.caramel.core.designsystem.di
+
+import org.koin.core.module.Module
+
+expect val hapticControllerModule: Module

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/util/HapticController.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/util/HapticController.kt
@@ -1,0 +1,16 @@
+package com.whatever.caramel.core.designsystem.util
+
+/**
+ * 각 플랫폼에서 제공하는 햅틱 피드백을 제어하는 인터페이스입니다.
+ * @author GunHyung-Ham
+ * @since 2025.04.02
+ */
+interface HapticController {
+
+    fun performImpact(style: HapticStyle)
+
+}
+
+enum class HapticStyle {
+    GestureThresholdActivate
+}

--- a/core/designsystem/src/iosMain/kotlin/com/whatever/caramel/core/designsystem/di/Modules.ios.kt
+++ b/core/designsystem/src/iosMain/kotlin/com/whatever/caramel/core/designsystem/di/Modules.ios.kt
@@ -1,0 +1,10 @@
+package com.whatever.caramel.core.designsystem.di
+
+import com.whatever.caramel.core.designsystem.util.HapticController
+import com.whatever.caramel.core.designsystem.util.IOSHapticController
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val hapticControllerModule: Module = module {
+    single<HapticController> { IOSHapticController() }
+}

--- a/core/designsystem/src/iosMain/kotlin/com/whatever/caramel/core/designsystem/util/HapticController.ios.kt
+++ b/core/designsystem/src/iosMain/kotlin/com/whatever/caramel/core/designsystem/util/HapticController.ios.kt
@@ -1,0 +1,15 @@
+package com.whatever.caramel.core.designsystem.util
+
+import platform.UIKit.UIImpactFeedbackGenerator
+import platform.UIKit.UIImpactFeedbackStyle
+
+class IOSHapticController : HapticController {
+    override fun performImpact(style: HapticStyle) {
+        val generator = when (style) {
+            HapticStyle.GestureThresholdActivate -> UIImpactFeedbackGenerator(UIImpactFeedbackStyle.UIImpactFeedbackStyleMedium)
+        }
+
+        generator.prepare()
+        generator.impactOccurred()
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- #51 

## 작업한 내용
- CaramelTextWheelPicker 구현

## PR 포인트
- SubComposeLayout 활용
  - 아이템이 보여줘야 하는 갯수는 총 3개로 이를 구현하기위해 Picker의 높이를 고정으로 잡았어야 했습니다. 고정된 높이를 잡기 위해 SubComposeLayout을 활용하여 아이템의 높이를 획득하고 `3가지 아이템의 높이 + 아이템 간격 + dividerThickness`를 LazyColumn의 높이로 설정하였습니다. 이때 아이템의 높이를 먼저 획득하고 LazyColumn의 높이를 설정하기 위해 SubComposeLayout을 사용하여 아이템 높이를 획득합니다.
- HapticController
  - 컴포즈에서 `LocalHapticFeedback`을 활용하여 햅틱의 강도를 설정할수 있습니다. 하지만 KMP 이슈인지.. 현재 `HapticFeedbackType.TextHandleMove`과 `HapticFeedbackType.LongPress`만 작동하고 있습니다. (다른 타입은 진동이 안울림) 때문에 직접 컨트롤러를 DI로 생성하여 각 플랫폼에서 주입받는 형식으로 구현하였습니다. 향후 햅팁 강도가 여러개로 나눠질 경우 확장성을 대비하여 HapticFeedbackType과 비슷한 형태로 구현될 예정입니다.

## Next
- UI 모듈 - DatePicker / TimePicker / MonthPicker 구현