### PR TITLE
[Feat] 디자인 시스템 - Toast 컴포넌트 구현

### DIFF
--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelComposeApp.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelComposeApp.kt
@@ -1,11 +1,16 @@
 package com.whatever.caramel.app
 
-import androidx.compose.material3.SnackbarHost
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import com.whatever.caramel.core.designsystem.components.CaramelSnackBarHost
+import com.whatever.caramel.core.designsystem.components.CaramelSnackbar
+import com.whatever.caramel.core.designsystem.components.LocalSnackbarHostState
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
 
 @Composable
@@ -15,17 +20,27 @@ fun CaramelComposeApp(
     CaramelTheme {
         val snackBarHostState = remember { SnackbarHostState() }
 
-        CaramelScaffold(
-            snackBarHost = {
-                SnackbarHost(
-                    hostState = snackBarHostState
-                )
-            },
+        CompositionLocalProvider(
+            LocalSnackbarHostState provides snackBarHostState
         ) {
-            CaramelNavHost(
-                modifier = Modifier,
-                navHostController = navHostController,
-            )
+            CaramelScaffold(
+                snackBarHost = {
+                    CaramelSnackBarHost(
+                        modifier = Modifier.padding(bottom = 20.dp),
+                        hostState = LocalSnackbarHostState.current,
+                        snackbar = { snackbarData ->
+                            CaramelSnackbar(
+                                snackbarData = snackbarData
+                            )
+                        },
+                    )
+                },
+            ) {
+                CaramelNavHost(
+                    modifier = Modifier,
+                    navHostController = navHostController
+                )
+            }
         }
     }
 }

--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelComposeApp.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelComposeApp.kt
@@ -26,7 +26,12 @@ fun CaramelComposeApp(
             CaramelScaffold(
                 snackBarHost = {
                     CaramelSnackBarHost(
-                        modifier = Modifier.padding(bottom = 20.dp),
+                        modifier = Modifier
+                            .padding(
+                                start = 20.dp,
+                                end = 20.dp,
+                                bottom = 20.dp
+                            ),
                         hostState = LocalSnackbarHostState.current,
                         snackbar = { snackbarData ->
                             CaramelSnackbar(

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/animation/SlideInSlideOutSnackbarHost.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/animation/SlideInSlideOutSnackbarHost.kt
@@ -97,7 +97,7 @@ fun SlideInSlideOutSnackbarHost(
 }
 
 private class FadeInFadeOutState<T> {
-    var current: Any? = Any()
+    var current: SnackbarData? = null
     var items = mutableListOf<FadeInFadeOutAnimationItem<T>>()
     var scope: RecomposeScope? = null
 }

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/animation/SlideInSlideOutSnackbarHost.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/animation/SlideInSlideOutSnackbarHost.kt
@@ -1,0 +1,145 @@
+package com.whatever.caramel.core.designsystem.animation
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.material3.SnackbarData
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.RecomposeScope
+import androidx.compose.runtime.State
+import androidx.compose.runtime.currentRecomposeScope
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.dismiss
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastFilterNotNull
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMapTo
+
+@Composable
+fun SlideInSlideOutSnackbarHost(
+    current: SnackbarData?,
+    modifier: Modifier = Modifier,
+    content: @Composable (SnackbarData) -> Unit
+) {
+    val state = remember { FadeInFadeOutState<SnackbarData?>() }
+    if (current != state.current) {
+        state.current = current
+        val keys = state.items.fastMap { it.key }.toMutableList()
+        if (!keys.contains(current)) {
+            keys.add(current)
+        }
+        state.items.clear()
+        keys.fastFilterNotNull().fastMapTo(state.items) { key ->
+            FadeInFadeOutAnimationItem(key) { children ->
+                val isVisible = key == current
+                val duration = if (isVisible) SnackbarFadeInMillis else SnackbarFadeOutMillis
+                val delay = SnackbarFadeOutMillis + SnackbarInBetweenDelayMillis
+                val animationDelay =
+                    if (isVisible && keys.fastFilterNotNull().size != 1) {
+                        delay
+                    } else {
+                        0
+                    }
+                val offsetY = animatedSlideOffsetY(
+                    animation = tween(
+                        easing = LinearEasing,
+                        delayMillis = animationDelay,
+                        durationMillis = duration
+                    ),
+                    visible = isVisible,
+                    onAnimationFinish = {
+                        if (key != state.current) {
+                            state.items.removeAll { it.key == key }
+                            state.scope?.invalidate()
+                        }
+                    }
+                )
+                val opacity = animatedOpacity(
+                    animation = tween(
+                        easing = LinearEasing,
+                        delayMillis = animationDelay,
+                        durationMillis = duration
+                    ),
+                    visible = isVisible
+                )
+                Box(
+                    modifier = Modifier
+                        .offset(y = offsetY.value.dp)
+                        .graphicsLayer(alpha = opacity.value)
+                        .semantics {
+                            liveRegion = LiveRegionMode.Polite
+                            dismiss {
+                                key.dismiss()
+                                true
+                            }
+                        }
+                ) {
+                    children()
+                }
+            }
+        }
+    }
+    Box(modifier) {
+        state.scope = currentRecomposeScope
+        state.items.fastForEach { (item, opacity) -> key(item) { opacity { content(item!!) } } }
+    }
+}
+
+private class FadeInFadeOutState<T> {
+    var current: Any? = Any()
+    var items = mutableListOf<FadeInFadeOutAnimationItem<T>>()
+    var scope: RecomposeScope? = null
+}
+
+private data class FadeInFadeOutAnimationItem<T>(
+    val key: T,
+    val transition: FadeInFadeOutTransition
+)
+
+private typealias FadeInFadeOutTransition = @Composable (content: @Composable () -> Unit) -> Unit
+
+@Composable
+private fun animatedOpacity(
+    animation: AnimationSpec<Float>,
+    visible: Boolean,
+    onAnimationFinish: () -> Unit = {}
+): State<Float> {
+    val alpha = remember { Animatable(if (!visible) 1f else 0f) }
+    LaunchedEffect(visible) {
+        alpha.animateTo(if (visible) 1f else 0f, animationSpec = animation)
+        onAnimationFinish()
+    }
+    return alpha.asState()
+}
+
+@Composable
+private fun animatedSlideOffsetY(
+    animation: AnimationSpec<Float>,
+    visible: Boolean,
+    onAnimationFinish: () -> Unit = {}
+): State<Float> {
+    val offsetY = remember { Animatable(if (visible) 100f else 0f) }
+    LaunchedEffect(visible) {
+        offsetY.animateTo(
+            targetValue = if (visible) 0f else 100f,
+            animationSpec = animation
+        )
+        onAnimationFinish()
+    }
+    return offsetY.asState()
+}
+
+private const val SnackbarFadeInMillis = 150
+private const val SnackbarFadeOutMillis = 150
+private const val SnackbarInBetweenDelayMillis = 0

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/SnackBar.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/SnackBar.kt
@@ -1,0 +1,99 @@
+package com.whatever.caramel.core.designsystem.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.SnackbarData
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import com.whatever.caramel.core.designsystem.animation.SlideInSlideOutSnackbarHost
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * 스낵바를 전역에서 접근하기 위해 compositionLocalOf를 사용하여 스낵바 호스트 상태를 제공합니다.
+ * @author GunHyung-Ham
+ * @since 2025.03.31
+ */
+val LocalSnackbarHostState = compositionLocalOf<SnackbarHostState> { error("No SnackbarHostState provided") }
+
+/**
+ * 스낵바를 제어하기 위한 호스트 컴포저블입니다.
+ * @author GunHyung-Ham
+ * @since 2025.03.31
+ */
+@Composable
+fun CaramelSnackBarHost(
+    modifier: Modifier = Modifier,
+    hostState: SnackbarHostState,
+    snackbar: @Composable (SnackbarData) -> Unit
+) {
+    val currentSnackbarData = hostState.currentSnackbarData
+
+    LaunchedEffect(currentSnackbarData) {
+        if (currentSnackbarData != null) {
+            val duration = when (currentSnackbarData.visuals.duration) {
+                SnackbarDuration.Indefinite -> Long.MAX_VALUE
+                SnackbarDuration.Long -> 10000L
+                SnackbarDuration.Short -> 3000L
+            }
+
+            delay(duration)
+
+            currentSnackbarData.dismiss()
+        }
+    }
+
+    SlideInSlideOutSnackbarHost(
+        current = hostState.currentSnackbarData,
+        modifier = modifier,
+        content = snackbar
+    )
+}
+
+@Composable
+fun CaramelSnackbar(
+    modifier: Modifier = Modifier,
+    snackbarData: SnackbarData,
+) {
+    Box(
+        modifier = modifier
+            .background(
+                color = Color(color = 0xFF54493F), // TODO : 토큰으로 변경하기
+                shape = CaramelTheme.shape.xl
+            )
+            .padding(
+                horizontal = CaramelTheme.spacing.xl,
+                vertical = CaramelTheme.spacing.m
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = snackbarData.visuals.message,
+            color = CaramelTheme.color.text.inverse,
+            style = CaramelTheme.typography.body3.regular,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+fun showSnackbarMessage(
+    coroutineScope: CoroutineScope,
+    snackbarHostState: SnackbarHostState,
+    message: String,
+) {
+    coroutineScope.launch {
+        snackbarHostState.currentSnackbarData?.dismiss()
+        snackbarHostState.showSnackbar(message = message)
+    }
+}

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/foundations/Shapes.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/foundations/Shapes.kt
@@ -11,5 +11,6 @@ internal enum class CaramelShapeDefaults(val shape: Shape) {
     RADIUS_M(shape = RoundedCornerShape(12.dp)),
     RADIUS_L(shape = RoundedCornerShape(16.dp)),
     RADIUS_XL(shape = RoundedCornerShape(24.dp)),
+    RADIUS_XXL(shape = RoundedCornerShape(100.dp)),
     ;
 }

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/themes/CaramelShape.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/themes/CaramelShape.kt
@@ -25,6 +25,7 @@ data class CaramelShape(
     val m: Shape,
     val l: Shape,
     val xl: Shape,
+    val xxl: Shape,
 ) {
     companion object {
         fun defaultRadius(): CaramelShape = CaramelShape (
@@ -34,6 +35,7 @@ data class CaramelShape(
             m = CaramelShapeDefaults.RADIUS_M.shape,
             l = CaramelShapeDefaults.RADIUS_L.shape,
             xl = CaramelShapeDefaults.RADIUS_XL.shape,
+            xxl = CaramelShapeDefaults.RADIUS_XXL.shape
         )
     }
 }

--- a/feature/couple/invite/src/commonMain/kotlin/com/whatever/caramel/feature/copule/invite/CoupleInviteRoute.kt
+++ b/feature/couple/invite/src/commonMain/kotlin/com/whatever/caramel/feature/copule/invite/CoupleInviteRoute.kt
@@ -3,8 +3,11 @@ package com.whatever.caramel.feature.copule.invite
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.whatever.caramel.core.designsystem.components.LocalSnackbarHostState
+import com.whatever.caramel.core.designsystem.components.showSnackbarMessage
 import com.whatever.caramel.feature.copule.invite.clipboard.createPlatformClipEntry
 import com.whatever.caramel.feature.copule.invite.mvi.CoupleInviteSideEffect
 import com.whatever.caramel.feature.copule.invite.share.ShareService
@@ -19,7 +22,9 @@ internal fun CoupleInviteRoute(
     navigateToLogin: () -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val scope = rememberCoroutineScope()
     val clipboard = LocalClipboard.current
+    val snackbarHostState = LocalSnackbarHostState.current
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->
@@ -27,6 +32,11 @@ internal fun CoupleInviteRoute(
                 is CoupleInviteSideEffect.NavigateToConnectCouple -> navigateToConnectCouple()
                 is CoupleInviteSideEffect.NavigateToLogin -> navigateToLogin()
                 is CoupleInviteSideEffect.CopyToClipBoardWithShowSnackBar -> {
+                    showSnackbarMessage(
+                        snackbarHostState = snackbarHostState,
+                        coroutineScope = scope,
+                        message = "초대 코드를 복사했습니다"
+                    )
                     clipboard.setClipEntry(
                         clipEntry = createPlatformClipEntry(
                             inviteCode = sideEffect.inviteCode


### PR DESCRIPTION
## 관련 이슈
- closed #89 

## 작업한 내용
- CaramelSnackbar 구현 a816224d0a22a20b88d1b01caa1a7c5b6d33e6d7
- 디자인 시스템 XXL 사이즈 Radius 추가 6eeb82fa7c4d1e021cdafe4f147523d1675d3de7

## PR 포인트
- LocalSnackbarHostState
  - Feature 모듈 전역에서 사용하기 위해 CompositionLocal를 활용한 방향으로 설계하였습니다.
- SlideInSlideOutSnackbarHost 애니메이션
  - Material3의 SnackbarHost 컴포저블을 사용할때 `FadeInFadeOutScale`이라는 고정된 애니메이션이 존재합니다. 요구사항에 맞춰 CaramelSnackbarHost 컴포저블 내부에 `SlideInSlideOutSnackbarHost` 애니메이션을 적용합니다.