### PR TITLE
Refactor/token type

### DIFF
--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/interceptor/TokenInterceptorImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/interceptor/TokenInterceptorImpl.kt
@@ -9,14 +9,12 @@ class TokenInterceptorImpl(
     private val tokenDataSource: TokenDataSource,
     private val authDataSource: RemoteAuthDataSource
 ) : TokenInterceptor {
+    override suspend fun getAccessToken(): String {
+        return tokenDataSource.fetchAccessToken()
+    }
 
-    override suspend fun getAuthToken(): Pair<String?, String?> {
-        val (accessToken, refreshToken) = tokenDataSource.fetchToken()
-
-        return Pair(
-            first = accessToken,
-            second = refreshToken
-        )
+    override suspend fun getRefreshToken(): String {
+        return tokenDataSource.fetchRefreshToken()
     }
 
     /**
@@ -28,7 +26,8 @@ class TokenInterceptorImpl(
      */
     override suspend fun refresh(): Boolean {
         try {
-            val (accessToken, refreshToken) = tokenDataSource.fetchToken()
+            val accessToken = tokenDataSource.fetchAccessToken()
+            val refreshToken = tokenDataSource.fetchRefreshToken()
 
             if (accessToken.isNotEmpty() && refreshToken.isNotEmpty()) {
                 val response = authDataSource.refresh(

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/AuthMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/AuthMapper.kt
@@ -12,9 +12,7 @@ fun SignInResponse.toUserAuth(): UserAuth {
         coupleId = this.coupleId,
         nickname = this.nickname,
         userStatus = UserStatus.valueOf(this.userStatus.name),
-        birthDayMillisecond = this.birthDay?.let {
-            Instant.parse(it).toEpochMilliseconds()
-        },
+        birthDayMillisecond = this.birthDay?.toTimezoneMillisecond(),
         authToken = serviceToken.toAuthToken()
     )
 }
@@ -23,10 +21,3 @@ fun ServiceToken.toAuthToken() = AuthToken(
     accessToken = this.accessToken,
     refreshToken = this.refreshToken
 )
-
-fun Pair<String, String>.toAuthToken(): AuthToken {
-    return AuthToken(
-        accessToken = this.first,
-        refreshToken = this.second
-    )
-}

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/DateMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/DateMapper.kt
@@ -1,0 +1,13 @@
+package com.whatever.caramel.core.data.mapper
+
+import kotlinx.datetime.Instant
+
+/**
+ * "YYYY-MM-DD"에 대한 밀리초 변환
+ * @return 변환 성공 시 해당 년원일에 대해 밀리초, 실패시 null
+ * */
+fun String.toTimezoneMillisecond() = try {
+    Instant.parse(this + "T00:00:00.000Z").toEpochMilliseconds()
+} catch (e: Exception) {
+    null
+}

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/repository/AuthRepositoryImpl.kt
@@ -54,7 +54,10 @@ internal class AuthRepositoryImpl(
 
     override suspend fun getAuthToken(): AuthToken {
         return safeCall {
-            tokenDataSource.fetchToken().toAuthToken()
+            AuthToken(
+                accessToken = tokenDataSource.fetchAccessToken(),
+                refreshToken = tokenDataSource.fetchRefreshToken()
+            )
         }
     }
 }

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/repository/CoupleRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/repository/CoupleRepositoryImpl.kt
@@ -14,7 +14,7 @@ class CoupleRepositoryImpl(
 ) : CoupleRepository {
     override suspend fun getCoupleInvitationCode(): CoupleInvitationCode {
         return safeCall {
-            remoteCoupleDataSource.generateCoupleInvitaionCode().toCoupleInvitationCode()
+            remoteCoupleDataSource.generateCoupleInvitationCode().toCoupleInvitationCode()
         }
     }
 

--- a/core/datastore/src/commonMain/kotlin/com/whatever/caramel/core/datastore/datasource/TokenDataSource.kt
+++ b/core/datastore/src/commonMain/kotlin/com/whatever/caramel/core/datastore/datasource/TokenDataSource.kt
@@ -7,6 +7,6 @@ interface TokenDataSource {
         refreshToken: String,
     )
 
-    suspend fun fetchToken(): Pair<String, String>
-
+    suspend fun fetchAccessToken() : String
+    suspend fun fetchRefreshToken(): String
 }

--- a/core/datastore/src/commonMain/kotlin/com/whatever/caramel/core/datastore/datasource/TokenDataSourceImpl.kt
+++ b/core/datastore/src/commonMain/kotlin/com/whatever/caramel/core/datastore/datasource/TokenDataSourceImpl.kt
@@ -20,15 +20,15 @@ class TokenDataSourceImpl(
         }
     }
 
-    override suspend fun fetchToken(): Pair<String, String> {
-        dataStore.data.first().let { prefs ->
-            val accessToken = prefs[accessTokenKey]
-            val refreshToken = prefs[refreshTokenKey]
+    override suspend fun fetchAccessToken(): String {
+        return dataStore.data.first().let { prefs ->
+            prefs[accessTokenKey] ?: ""
+        }
+    }
 
-            return Pair(
-                first = accessToken ?: "",
-                second = refreshToken ?: ""
-            )
+    override suspend fun fetchRefreshToken(): String {
+        return dataStore.data.first().let { prefs ->
+            prefs[refreshTokenKey] ?: ""
         }
     }
 

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/couple/ConnectCoupleUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/couple/ConnectCoupleUseCase.kt
@@ -6,10 +6,10 @@ import com.whatever.caramel.core.domain.vo.user.UserStatus
 
 class ConnectCoupleUseCase(
     private val userRepository: UserRepository,
-    private val coupleRepository: CoupleRepository
+    private val coupleRepository: CoupleRepository,
 ) {
     suspend operator fun invoke(
-        invitationCode: String
+        invitationCode: String,
     ) {
         coupleRepository.connectCouple(invitationCode)
         userRepository.setUserStatus(UserStatus.COUPLED)

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/user/CreateUserProfileUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/user/CreateUserProfileUseCase.kt
@@ -17,14 +17,14 @@ class CreateUserProfileUseCase(
     ) {
         UserValidator.checkNicknameValidate(nickname)
             .onSuccess {
-                userRepository.createUserProfile(
+                val createProfileResult = userRepository.createUserProfile(
                     nickname = nickname,
                     birthDay = birthDay,
                     gender = gender,
                     agreementServiceTerms = agreementServiceTerms,
                     agreementPrivacyPolicy = agreementPrivacyPolicy
                 )
-                userRepository.setUserStatus(UserStatus.SINGLE)
+                userRepository.setUserStatus(createProfileResult.userStatus)
             }.onFailure {
                 throw it
             }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/datasource/RemoteCoupleDataSource.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/datasource/RemoteCoupleDataSource.kt
@@ -5,6 +5,6 @@ import com.whatever.caramel.core.remote.dto.couple.CoupleConnectResponse
 import com.whatever.caramel.core.remote.dto.couple.CoupleInvitationCodeResponse
 
 interface RemoteCoupleDataSource {
-    suspend fun generateCoupleInvitaionCode(): CoupleInvitationCodeResponse
+    suspend fun generateCoupleInvitationCode(): CoupleInvitationCodeResponse
     suspend fun connectCouple(request: CoupleConnectRequest): CoupleConnectResponse
 }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/datasource/RemoteCoupleDatsSourceImpl.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/datasource/RemoteCoupleDatsSourceImpl.kt
@@ -12,7 +12,7 @@ import org.koin.core.annotation.Named
 class RemoteCoupleDatsSourceImpl(
     @Named("AuthClient") private val authClient: HttpClient
 ) : RemoteCoupleDataSource {
-    override suspend fun generateCoupleInvitaionCode(): CoupleInvitationCodeResponse {
+    override suspend fun generateCoupleInvitationCode(): CoupleInvitationCodeResponse {
         return authClient.post(POST_COUPLE_INVITATION_CODE_URL).getBody()
     }
 

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/di/Module.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/di/Module.kt
@@ -51,10 +51,10 @@ val networkModule = module {
             install(Auth) {
                 bearer {
                     loadTokens {
-                        val (accessToken, refreshToken) = get<TokenInterceptor>().getAuthToken()
+                        val accessToken = get<TokenInterceptor>().getAccessToken()
 
-                        if (accessToken != null && refreshToken != null) {
-                            BearerTokens(accessToken, refreshToken)
+                        if (accessToken.isNotEmpty()) {
+                            BearerTokens(accessToken, null)
                         } else {
                             null
                         }
@@ -64,9 +64,10 @@ val networkModule = module {
                         val refreshed = get<TokenInterceptor>().refresh()
 
                         if (refreshed) {
-                            val (accessToken, refreshToken) = get<TokenInterceptor>().getAuthToken()
+                            val accessToken = get<TokenInterceptor>().getAccessToken()
+                            val refreshToken = get<TokenInterceptor>().getRefreshToken()
 
-                            if (accessToken != null && refreshToken != null) {
+                            if (accessToken.isNotEmpty() && refreshToken.isNotEmpty()) {
                                 BearerTokens(accessToken, refreshToken)
                             } else {
                                 null

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/network/config/CaramelDefaultRequest.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/network/config/CaramelDefaultRequest.kt
@@ -1,6 +1,5 @@
 package com.whatever.caramel.core.remote.network.config
 
-import com.whatever.caramel.core.remote.network.config.NetworkConfig
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.plugins.DefaultRequest
 import io.ktor.http.ContentType

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/network/interceptor/TokenInterceptor.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/network/interceptor/TokenInterceptor.kt
@@ -2,8 +2,8 @@ package com.whatever.caramel.core.remote.network.interceptor
 
 interface TokenInterceptor {
 
-    suspend fun getAuthToken() : Pair<String?, String?>
-
+    suspend fun getAccessToken() : String
+    suspend fun getRefreshToken() : String
     suspend fun refresh(): Boolean
 
 }

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateViewModel.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateViewModel.kt
@@ -56,7 +56,7 @@ class ProfileCreateViewModel(
             launch {
                 createUserProfileUseCase(
                     nickname = currentState.nickname,
-                    birthDay = "${currentState.birthday.year}-${currentState.birthday.month}-${currentState.birthday.day}",
+                    birthDay = currentState.birthday.toDateFormat(),
                     gender = currentState.gender,
                     agreementServiceTerms = currentState.isServiceTermChecked,
                     agreementPrivacyPolicy = currentState.isPersonalInfoTermChecked

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/mvi/ProfileCreateState.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/mvi/ProfileCreateState.kt
@@ -47,6 +47,16 @@ data class Birthday(
     val month: String = "",
     val day: String = ""
 ) {
+    fun toDateFormat() : String {
+        fun toFormatNumber(number : String) = if(number.toInt() in 1..9){
+            "0$number"
+        } else {
+            number
+        }
+
+        return "${year}-${toFormatNumber(month)}-${toFormatNumber(day)}"
+    }
+
     companion object {
         fun currentDay(): Birthday {
             val currentDay =


### PR DESCRIPTION
## 관련 이슈
#71 

## 작업한 내용
- AccessToken ,RefreshToken을 `Pair<String, String>`이 아닌 각각 메소드로 분리
-` AuthClient` 토큰 로직 수정
  - `loadTokens`에 AccessToken만 불러오도록 수정
  - `refreshToken`에 AccessToken와 RefreshToken을 불러오도록 수정
- 비즈니스 로직에 대한 책임을 서버로 전달

## PR 포인트

### 1. Token 로직 분리
일전에 말씀드렸던 것 처럼 Token을 `Pair`로 가져오는 것이 아닌 각각 메소드를 통해서 불러오도록 수정했습니다.

### 2. 비즈니스 로직에 대한 책임
Server-Driven이기 때문에 모든 것을 서버에서 책임을 담당하고자 합니다.
따라서 유즈케이스에서도 서버 응답 기준으로 값을 변경`(Preference, Room)` 해야합니다.
```
        UserValidator.checkNicknameValidate(nickname)
            .onSuccess {
                userRepository.createUserProfile(
                    nickname = nickname,
                    birthDay = birthDay,
                    gender = gender,
                    agreementServiceTerms = agreementServiceTerms,
                    agreementPrivacyPolicy = agreementPrivacyPolicy
                )
                // 서버에서 유저 상태 업데이트가 되지 않는 오류가 있었는데 앱에서 자체적으로 변경 -> 서버 로직과 다름
                // 서버 기준으로 변경 -> userRepository.setUserStatus(createProfileResult.userStatus)
                userRepository.setUserStatus(UserStatus.SINGLE) 
            }.onFailure {
                throw it
            }
```

### 3. `Birthday`를 서버로 전달할 경우 예외 발생
현재 요청과 파싱에서 전부 오류가 발생하고 있습니다. (응답의 경우 #93 에서 수정되었습니다)
- **요청**
  - Request = 2025-4-7
  - Server Expected = 2025-04-07, Result = 유효하지 않는 파라미터
  - 따라서 `Birthday` 내부에 `toDateFormat`을 구현해놨지만 다른 상태 생성에 대한 위험 뿐만 아니라 해당 로직이 다른 곳에도 많이 사용될 것 같아 core-util 모듈을 만들어야 할 것 같습니다.

유틸 모듈에 대한 범위는 일전에 말씀드렸던 것 처럼 정말 작은 단위 (날짜 파싱, 간단한 확장 함수)로 구현될 예정입니다. 해당 부분에서 궁금하신점 있으시다면 언제든지 멘션주십쇼! (허들 환영)