### PR TITLE
[Feat] Dialog 컴포넌트 구현

### DIFF
--- a/core/designsystem/src/androidMain/kotlin/com/whatever/caramel/core/designsystem/DialogPreview.kt
+++ b/core/designsystem/src/androidMain/kotlin/com/whatever/caramel/core/designsystem/DialogPreview.kt
@@ -1,0 +1,73 @@
+package com.whatever.caramel.core.designsystem
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.whatever.caramel.core.designsystem.components.CaramelDialog
+import com.whatever.caramel.core.designsystem.components.DefaultCaramelDialogLayout
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+
+data class CaramelDialogPreviewData(
+    val title: String,
+    val message: String? = null,
+    val mainButtonText: String,
+    val subButtonText: String? = null,
+    val mainButtonClickEvent: () -> Unit,
+    val subButtonClickEvent: (() -> Unit)? = null,
+)
+
+class CaramelDialogPreviewProvider : PreviewParameterProvider<CaramelDialogPreviewData> {
+    override val values: Sequence<CaramelDialogPreviewData>
+        get() = sequenceOf(
+            CaramelDialogPreviewData(
+                title = "Default Title",
+                message = "This is a default message",
+                mainButtonText = "OK",
+                subButtonText = "Cancel",
+                mainButtonClickEvent = {},
+                subButtonClickEvent = {}
+            ),
+            CaramelDialogPreviewData(
+                title = "Default Title",
+                message = "This is a default message",
+                mainButtonText = "OK",
+                mainButtonClickEvent = {}
+            ),
+            CaramelDialogPreviewData(
+                title = "Default Title",
+                mainButtonText = "OK",
+                subButtonText = "Cancel",
+                mainButtonClickEvent = {},
+                subButtonClickEvent = {}
+            ),
+            CaramelDialogPreviewData(
+                title = "Default Title",
+                mainButtonText = "OK",
+                subButtonText = "Cancel",
+                mainButtonClickEvent = {},
+                subButtonClickEvent = {}
+            )
+        )
+}
+
+@Preview
+@Composable
+private fun CaramelDialogPreview(
+    @PreviewParameter(CaramelDialogPreviewProvider::class) data: CaramelDialogPreviewData,
+) {
+    CaramelTheme {
+        CaramelDialog(
+            show = true,
+            onDismissRequest = {},
+            title = data.title,
+            message = data.message,
+            mainButtonText = data.mainButtonText,
+            subButtonText = data.subButtonText,
+            onSubButtonClick = data.subButtonClickEvent,
+            onMainButtonClick = data.mainButtonClickEvent
+        ) {
+            DefaultCaramelDialogLayout()
+        }
+    }
+}

--- a/core/designsystem/src/androidMain/kotlin/com/whatever/caramel/core/designsystem/DialogPreview.kt
+++ b/core/designsystem/src/androidMain/kotlin/com/whatever/caramel/core/designsystem/DialogPreview.kt
@@ -38,8 +38,7 @@ class CaramelDialogPreviewProvider : PreviewParameterProvider<CaramelDialogPrevi
                 title = "Default Title",
                 mainButtonText = "OK",
                 subButtonText = "Cancel",
-                mainButtonClickEvent = {},
-                subButtonClickEvent = {}
+                mainButtonClickEvent = {}
             ),
             CaramelDialogPreviewData(
                 title = "Default Title",

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
@@ -49,13 +49,13 @@ class CaramelDefaultDialogScope(
 @Composable
 fun CaramelDialog(
     show: Boolean,
-    onDismissRequest: () -> Unit,
     title: String,
     message: String? = null,
-    onSubButtonClick: (() -> Unit)? = null,
     subButtonText: String? = null,
     mainButtonText: String,
+    onDismissRequest: () -> Unit,
     onMainButtonClick: () -> Unit,
+    onSubButtonClick: (() -> Unit)? = null,
     content: @Composable CaramelDialogScope.() -> Unit,
 ) {
     if (!show) return

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
@@ -105,8 +105,8 @@ fun CaramelDialogScope.DefaultCaramelDialogLayout() {
             Spacer(Modifier.height(CaramelTheme.spacing.xs))
             CaramelDialogContent()
         }
+        Spacer(Modifier.height(CaramelTheme.spacing.xl))
         if (hasSubButton) {
-            Spacer(Modifier.height(CaramelTheme.spacing.xl))
             Row(
                 modifier = Modifier
                     .fillMaxWidth(),

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
@@ -1,19 +1,38 @@
 package com.whatever.caramel.core.designsystem.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.Button
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.modifier.modifierLocalMapOf
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
 
 @Stable
 interface CaramelDialogScope {
     val onDismissRequest: () -> Unit
 
-    val title : String
-    val message : String?
+    val title: String
+    val message: String?
 
-    val mainButtonText : String
-    val onMainButtonClick : () -> Unit
+    val mainButtonText: String
+    val onMainButtonClick: () -> Unit
 
-    val subButtonText : String?
-    val onSubButtonClick : (() -> Unit)?
+    val subButtonText: String?
+    val onSubButtonClick: (() -> Unit)?
 }
 
 class CaramelDefaultDialogScope(
@@ -23,5 +42,142 @@ class CaramelDefaultDialogScope(
     override val mainButtonText: String,
     override val onMainButtonClick: () -> Unit,
     override val subButtonText: String?,
-    override val onSubButtonClick: (() -> Unit)?
+    override val onSubButtonClick: (() -> Unit)?,
 ) : CaramelDialogScope
+
+@Composable
+fun CaramelDialog(
+    show: Boolean,
+    onDismissRequest: () -> Unit,
+    title: String,
+    message: String? = null,
+    onSubButtonClick: (() -> Unit)? = null,
+    subButtonText: String? = null,
+    mainButtonText: String,
+    onMainButtonClick: () -> Unit,
+    content: @Composable CaramelDialogScope.() -> Unit,
+) {
+    if (!show) return
+
+    val scope = remember(
+        onDismissRequest,
+        title,
+        message,
+        onSubButtonClick,
+        subButtonText,
+        mainButtonText,
+        onMainButtonClick
+    ) {
+        CaramelDefaultDialogScope(
+            onDismissRequest = onDismissRequest,
+            title = title,
+            message = message,
+            mainButtonText = mainButtonText,
+            onMainButtonClick = onMainButtonClick,
+            subButtonText = subButtonText,
+            onSubButtonClick = onSubButtonClick
+        )
+    }
+    Dialog(
+        onDismissRequest = onDismissRequest
+    ) {
+        Surface(
+            modifier = Modifier.wrapContentHeight(),
+            shape = CaramelTheme.shape.l,
+            color = CaramelTheme.color.background.tertiary
+        ) {
+            scope.content()
+        }
+    }
+}
+
+@Composable
+fun CaramelDialogScope.DefaultCaramelDialogLayout() {
+    val hasMessage = !message.isNullOrBlank()
+    val hasSubButton = !subButtonText.isNullOrBlank() && onSubButtonClick != null
+    Column(
+        modifier = Modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CaramelDialogTitle()
+        if (hasMessage) {
+            Spacer(Modifier.padding(bottom = CaramelTheme.spacing.xs))
+            CaramelDialogContent()
+        }
+        Spacer(Modifier.padding(bottom = CaramelTheme.spacing.xl))
+        if (hasSubButton) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = CaramelTheme.spacing.xl),
+                horizontalArrangement = Arrangement.spacedBy(CaramelTheme.spacing.s),
+            ) {
+                CaramelDialogMainButton(modifier = Modifier.weight(1f))
+                CaramelDialogSubButton(modifier = Modifier.weight(1f))
+            }
+        } else {
+            CaramelDialogMainButton(modifier = Modifier.fillMaxWidth())
+        }
+    }
+}
+
+@Composable
+fun CaramelDialogScope.CaramelDialogTitle(
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        modifier = modifier.fillMaxWidth(),
+        text = this.title,
+        style = CaramelTheme.typography.body1.bold,
+        color = CaramelTheme.color.text.primary
+    )
+}
+
+@Composable
+fun CaramelDialogScope.CaramelDialogContent(
+    modifier: Modifier = Modifier,
+) {
+    val dialogMessage = this.message ?: return
+    Text(
+        modifier = modifier.fillMaxWidth(),
+        text = dialogMessage,
+        style = CaramelTheme.typography.body2.regular,
+        color = CaramelTheme.color.text.primary
+    )
+}
+
+@Composable
+fun CaramelDialogScope.CaramelDialogMainButton(
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        modifier = modifier
+            .background(color = CaramelTheme.color.fill.brand, shape = CaramelTheme.shape.xxl),
+        onClick = { this.onMainButtonClick() }
+    ) {
+        Text(
+            text = mainButtonText,
+            style = CaramelTheme.typography.body3.bold,
+            color = CaramelTheme.color.text.inverse
+        )
+    }
+}
+
+@Composable
+fun CaramelDialogScope.CaramelDialogSubButton(
+    modifier: Modifier = Modifier,
+) {
+    val subButtonText = this.subButtonText ?: return
+    val subButtonClickEvent = this.onSubButtonClick ?: return
+
+    Button(
+        modifier = modifier,
+        onClick = { subButtonClickEvent() }
+    ) {
+        Text(
+            text = subButtonText,
+            style = CaramelTheme.typography.body3.bold,
+            color = CaramelTheme.color.text.brand
+        )
+    }
+}

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Button
@@ -101,10 +102,10 @@ fun CaramelDialogScope.DefaultCaramelDialogLayout() {
     ) {
         CaramelDialogTitle()
         if (hasMessage) {
-            Spacer(Modifier.padding(bottom = CaramelTheme.spacing.xs))
+            Spacer(Modifier.height(CaramelTheme.spacing.xs))
             CaramelDialogContent()
         }
-        Spacer(Modifier.padding(bottom = CaramelTheme.spacing.xl))
+        Spacer(Modifier.height(CaramelTheme.spacing.xl))
         if (hasSubButton) {
             Row(
                 modifier = Modifier

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
@@ -105,8 +105,8 @@ fun CaramelDialogScope.DefaultCaramelDialogLayout() {
             Spacer(Modifier.height(CaramelTheme.spacing.xs))
             CaramelDialogContent()
         }
-        Spacer(Modifier.height(CaramelTheme.spacing.xl))
         if (hasSubButton) {
+            Spacer(Modifier.height(CaramelTheme.spacing.xl))
             Row(
                 modifier = Modifier
                     .fillMaxWidth(),

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
@@ -98,14 +98,13 @@ fun CaramelDialogScope.DefaultCaramelDialogLayout() {
     val hasSubButton = !subButtonText.isNullOrBlank() && onSubButtonClick != null
     Column(
         modifier = Modifier.padding(all = CaramelTheme.spacing.xl),
+        verticalArrangement = Arrangement.spacedBy(CaramelTheme.spacing.xs),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         CaramelDialogTitle()
         if (hasMessage) {
-            Spacer(Modifier.height(CaramelTheme.spacing.xs))
             CaramelDialogContent()
         }
-        Spacer(Modifier.height(CaramelTheme.spacing.xl))
         if (hasSubButton) {
             Row(
                 modifier = Modifier
@@ -152,7 +151,7 @@ fun CaramelDialogScope.CaramelDialogMainButton(
 ) {
     Button(
         modifier = modifier,
-        contentPadding = PaddingValues(vertical = 11.dp),
+        contentPadding = PaddingValues(vertical = 11.dp, horizontal = CaramelTheme.spacing.l),
         onClick = this.onMainButtonClick,
         colors = ButtonColors(
             containerColor = CaramelTheme.color.fill.brand,
@@ -178,7 +177,7 @@ fun CaramelDialogScope.CaramelDialogSubButton(
 
     Button(
         modifier = modifier,
-        contentPadding = PaddingValues(vertical = 11.dp),
+        contentPadding = PaddingValues(vertical = 11.dp, horizontal = CaramelTheme.spacing.l),
         onClick = subButtonClickEvent,
         colors = ButtonColors(
             containerColor = CaramelTheme.color.fill.quinary,

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
@@ -1,6 +1,5 @@
 package com.whatever.caramel.core.designsystem.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -18,8 +17,6 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.modifier.modifierLocalMapOf
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
@@ -155,7 +152,7 @@ fun CaramelDialogScope.CaramelDialogMainButton(
     Button(
         modifier = modifier,
         contentPadding = PaddingValues(vertical = 11.dp),
-        onClick = { this.onMainButtonClick() },
+        onClick = this.onMainButtonClick,
         colors = ButtonColors(
             containerColor = CaramelTheme.color.fill.brand,
             contentColor = CaramelTheme.color.text.inverse,
@@ -181,7 +178,7 @@ fun CaramelDialogScope.CaramelDialogSubButton(
     Button(
         modifier = modifier,
         contentPadding = PaddingValues(vertical = 11.dp),
-        onClick = { subButtonClickEvent() },
+        onClick = subButtonClickEvent,
         colors = ButtonColors(
             containerColor = CaramelTheme.color.fill.quinary,
             contentColor = CaramelTheme.color.text.brand,

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
@@ -1,0 +1,27 @@
+package com.whatever.caramel.core.designsystem.components
+
+import androidx.compose.runtime.Stable
+
+@Stable
+interface CaramelDialogScope {
+    val onDismissRequest: () -> Unit
+
+    val title : String
+    val message : String?
+
+    val mainButtonText : String
+    val onMainButtonClick : () -> Unit
+
+    val subButtonText : String?
+    val onSubButtonClick : (() -> Unit)?
+}
+
+class CaramelDefaultDialogScope(
+    override val onDismissRequest: () -> Unit,
+    override val title: String,
+    override val message: String?,
+    override val mainButtonText: String,
+    override val onMainButtonClick: () -> Unit,
+    override val subButtonText: String?,
+    override val onSubButtonClick: (() -> Unit)?
+) : CaramelDialogScope

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
@@ -33,17 +33,17 @@ interface CaramelDialogScope {
     val onMainButtonClick: () -> Unit
 
     val subButtonText: String?
-    val onSubButtonClick: (() -> Unit)?
+    val onSubButtonClick: () -> Unit
 }
 
 class CaramelDefaultDialogScope(
-    override val onDismissRequest: () -> Unit,
     override val title: String,
     override val message: String?,
     override val mainButtonText: String,
-    override val onMainButtonClick: () -> Unit,
     override val subButtonText: String?,
-    override val onSubButtonClick: (() -> Unit)?,
+    override val onDismissRequest: () -> Unit,
+    override val onMainButtonClick: () -> Unit,
+    override val onSubButtonClick: () -> Unit
 ) : CaramelDialogScope
 
 @Composable
@@ -55,7 +55,7 @@ fun CaramelDialog(
     mainButtonText: String,
     onDismissRequest: () -> Unit,
     onMainButtonClick: () -> Unit,
-    onSubButtonClick: (() -> Unit)? = null,
+    onSubButtonClick: () -> Unit = {},
     content: @Composable CaramelDialogScope.() -> Unit,
 ) {
     if (!show) return
@@ -95,7 +95,7 @@ fun CaramelDialog(
 @Composable
 fun CaramelDialogScope.DefaultCaramelDialogLayout() {
     val hasMessage = !message.isNullOrBlank()
-    val hasSubButton = !subButtonText.isNullOrBlank() && onSubButtonClick != null
+    val hasSubButton = !subButtonText.isNullOrBlank()
     Column(
         modifier = Modifier.padding(all = CaramelTheme.spacing.xl),
         verticalArrangement = Arrangement.spacedBy(CaramelTheme.spacing.xs),
@@ -173,12 +173,11 @@ fun CaramelDialogScope.CaramelDialogSubButton(
     modifier: Modifier = Modifier,
 ) {
     val subButtonText = this.subButtonText ?: return
-    val subButtonClickEvent = this.onSubButtonClick ?: return
 
     Button(
         modifier = modifier,
         contentPadding = PaddingValues(vertical = 11.dp, horizontal = CaramelTheme.spacing.l),
-        onClick = subButtonClickEvent,
+        onClick = this.onSubButtonClick,
         colors = ButtonColors(
             containerColor = CaramelTheme.color.fill.quinary,
             contentColor = CaramelTheme.color.text.brand,

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
@@ -3,12 +3,14 @@ package com.whatever.caramel.core.designsystem.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,6 +18,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.modifier.modifierLocalMapOf
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -96,7 +99,7 @@ fun CaramelDialogScope.DefaultCaramelDialogLayout() {
     val hasMessage = !message.isNullOrBlank()
     val hasSubButton = !subButtonText.isNullOrBlank() && onSubButtonClick != null
     Column(
-        modifier = Modifier,
+        modifier = Modifier.padding(all = CaramelTheme.spacing.xl),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         CaramelDialogTitle()
@@ -108,8 +111,7 @@ fun CaramelDialogScope.DefaultCaramelDialogLayout() {
         if (hasSubButton) {
             Row(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = CaramelTheme.spacing.xl),
+                    .fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(CaramelTheme.spacing.s),
             ) {
                 CaramelDialogMainButton(modifier = Modifier.weight(1f))
@@ -151,14 +153,20 @@ fun CaramelDialogScope.CaramelDialogMainButton(
     modifier: Modifier = Modifier,
 ) {
     Button(
-        modifier = modifier
-            .background(color = CaramelTheme.color.fill.brand, shape = CaramelTheme.shape.xxl),
-        onClick = { this.onMainButtonClick() }
+        modifier = modifier,
+        contentPadding = PaddingValues(vertical = 11.dp),
+        onClick = { this.onMainButtonClick() },
+        colors = ButtonColors(
+            containerColor = CaramelTheme.color.fill.brand,
+            contentColor = CaramelTheme.color.text.inverse,
+            disabledContentColor = CaramelTheme.color.text.disabledPrimary,
+            disabledContainerColor = CaramelTheme.color.fill.disabledPrimary
+        ),
+        shape = CaramelTheme.shape.xxl
     ) {
         Text(
             text = mainButtonText,
-            style = CaramelTheme.typography.body3.bold,
-            color = CaramelTheme.color.text.inverse
+            style = CaramelTheme.typography.body3.bold
         )
     }
 }
@@ -172,12 +180,19 @@ fun CaramelDialogScope.CaramelDialogSubButton(
 
     Button(
         modifier = modifier,
-        onClick = { subButtonClickEvent() }
+        contentPadding = PaddingValues(vertical = 11.dp),
+        onClick = { subButtonClickEvent() },
+        colors = ButtonColors(
+            containerColor = CaramelTheme.color.fill.quinary,
+            contentColor = CaramelTheme.color.text.brand,
+            disabledContentColor = CaramelTheme.color.text.disabledPrimary,
+            disabledContainerColor = CaramelTheme.color.fill.disabledPrimary
+        ),
+        shape = CaramelTheme.shape.xxl
     ) {
         Text(
             text = subButtonText,
-            style = CaramelTheme.typography.body3.bold,
-            color = CaramelTheme.color.text.brand
+            style = CaramelTheme.typography.body3.bold
         )
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #104 

## 작업한 내용
- Compound Component 방식으로 Dialog 구현

## PR 포인트
<img width="269" alt="image" src="https://github.com/user-attachments/assets/36f8c55d-36f8-42dc-9471-4a5f8a9cc542" />


디자인 시스템에 존재한 다이얼로그를 일전에 공유해주신 [아티클](https://haeti.palms.blog/compose-compound-components)을 보고 구현하였습니다.

컴파운드 컴포넌트 방식으로 설계하였고 현재 버튼의 경우 Scope내의 자식 컴포넌트로 구현되어 있습니다. 이는 버튼 컴포넌트 이슈를 추가하여 추후 변경 시키겠습니다.