### PR TITLE
[Feat] 커플 연결 화면 및 로직 구현

### DIFF
--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
@@ -3,15 +3,13 @@ package com.whatever.caramel.app
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
-import androidx.navigation.NavOptions
 import androidx.navigation.compose.NavHost
-import androidx.navigation.navOptions
 import com.whatever.caramel.feature.content.navigation.contentScreen
 import com.whatever.caramel.feature.content.navigation.navigateToContent
-import com.whatever.caramel.feature.couple.connect.navigation.connectCoupleScreen
-import com.whatever.caramel.feature.couple.connect.navigation.navigateToConnectCouple
 import com.whatever.caramel.feature.copule.invite.navigation.inviteCoupleScreen
 import com.whatever.caramel.feature.copule.invite.navigation.navigateToCoupleInvite
+import com.whatever.caramel.feature.couple.connect.navigation.connectCoupleScreen
+import com.whatever.caramel.feature.couple.connect.navigation.navigateToConnectCouple
 import com.whatever.caramel.feature.login.navigation.loginScreen
 import com.whatever.caramel.feature.login.navigation.navigateToLogin
 import com.whatever.caramel.feature.main.navigation.mainGraph
@@ -41,16 +39,20 @@ internal fun CaramelNavHost(
             splashScreen(
                 navigateToLogin = { navigateToLogin() },
                 navigateToMain = { navigateToMain() },
-                navigateToConnectCouple = { navigateToConnectCouple(
-                    navOptions = NavOptions.Builder()
-                        .setPopUpTo<SplashRoute>(inclusive = true)
-                        .build()
-                ) },
-                navigateToCreateProfile = { navigateToCreateProfile(
-                    navOptions = NavOptions.Builder()
-                        .setPopUpTo<SplashRoute>(inclusive = true)
-                        .build()
-                ) }
+                navigateToConnectCouple = {
+                    navigateToConnectCouple {
+                        popUpTo(route = SplashRoute) {
+                            inclusive = true
+                        }
+                    }
+                },
+                navigateToCreateProfile = {
+                    navigateToCreateProfile {
+                        popUpTo(route = SplashRoute) {
+                            inclusive = true
+                        }
+                    }
+                }
             )
             loginScreen(
                 navigateToConnectCouple = { navigateToCoupleInvite() },
@@ -75,7 +77,7 @@ internal fun CaramelNavHost(
                 },
                 navigateToLogin = {
                     navigateToLogin {
-                        popUpTo(SettingRoute){
+                        popUpTo(SettingRoute) {
                             inclusive = true
                         }
                     }

--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
@@ -39,8 +39,8 @@ internal fun CaramelNavHost(
             splashScreen(
                 navigateToLogin = { navigateToLogin() },
                 navigateToMain = { navigateToMain() },
-                navigateToConnectCouple = {
-                    navigateToConnectCouple {
+                navigateToInviteCouple = {
+                    navigateToCoupleInvite {
                         popUpTo(route = SplashRoute) {
                             inclusive = true
                         }

--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
@@ -7,7 +7,7 @@ import androidx.navigation.compose.NavHost
 import com.whatever.caramel.feature.content.navigation.contentScreen
 import com.whatever.caramel.feature.content.navigation.navigateToContent
 import com.whatever.caramel.feature.copule.invite.navigation.inviteCoupleScreen
-import com.whatever.caramel.feature.copule.invite.navigation.navigateToCoupleInvite
+import com.whatever.caramel.feature.copule.invite.navigation.navigateToInviteCouple
 import com.whatever.caramel.feature.couple.connect.navigation.connectCoupleScreen
 import com.whatever.caramel.feature.couple.connect.navigation.navigateToConnectCouple
 import com.whatever.caramel.feature.login.navigation.loginScreen
@@ -40,7 +40,7 @@ internal fun CaramelNavHost(
                 navigateToLogin = { navigateToLogin() },
                 navigateToMain = { navigateToMain() },
                 navigateToInviteCouple = {
-                    navigateToCoupleInvite {
+                    navigateToInviteCouple {
                         popUpTo(route = SplashRoute) {
                             inclusive = true
                         }
@@ -55,13 +55,13 @@ internal fun CaramelNavHost(
                 }
             )
             loginScreen(
-                navigateToConnectCouple = { navigateToCoupleInvite() },
+                navigateToConnectCouple = { navigateToInviteCouple() },
                 navigateToCreateProfile = { navigateToCreateProfile() },
                 navigateToMain = { navigateToMain() }
             )
             createProfileScreen(
                 navigateToLogin = { navigateToLogin() },
-                navigateToConnectCouple = { navigateToCoupleInvite() }
+                navigateToConnectCouple = { navigateToInviteCouple() }
             )
             settingScreen(
                 navigateToHome = { popBackStack() },

--- a/core/designsystem/src/androidMain/kotlin/com/whatever/caramel/core/designsystem/DialogPreview.kt
+++ b/core/designsystem/src/androidMain/kotlin/com/whatever/caramel/core/designsystem/DialogPreview.kt
@@ -9,12 +9,12 @@ import com.whatever.caramel.core.designsystem.components.DefaultCaramelDialogLay
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
 
 data class CaramelDialogPreviewData(
-    val title: String,
+    val title: String = "",
     val message: String? = null,
-    val mainButtonText: String,
+    val mainButtonText: String = "",
     val subButtonText: String? = null,
-    val mainButtonClickEvent: () -> Unit,
-    val subButtonClickEvent: (() -> Unit)? = null,
+    val mainButtonClickEvent: () -> Unit = {},
+    val subButtonClickEvent: () -> Unit = {},
 )
 
 class CaramelDialogPreviewProvider : PreviewParameterProvider<CaramelDialogPreviewData> {
@@ -32,13 +32,15 @@ class CaramelDialogPreviewProvider : PreviewParameterProvider<CaramelDialogPrevi
                 title = "Default Title",
                 message = "This is a default message",
                 mainButtonText = "OK",
-                mainButtonClickEvent = {}
+                mainButtonClickEvent = {},
+                subButtonClickEvent = {}
             ),
             CaramelDialogPreviewData(
                 title = "Default Title",
                 mainButtonText = "OK",
                 subButtonText = "Cancel",
-                mainButtonClickEvent = {}
+                mainButtonClickEvent = {},
+                subButtonClickEvent = {}
             ),
             CaramelDialogPreviewData(
                 title = "Default Title",

--- a/feature/couple/connect/src/androidMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectScreenPreview.kt
+++ b/feature/couple/connect/src/androidMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectScreenPreview.kt
@@ -1,0 +1,20 @@
+package com.whatever.caramel.feature.couple.connect
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.feature.couple.connect.mvi.CoupleConnectState
+
+@Preview
+@Composable
+private fun CoupleConnectScreenPreview(
+    @PreviewParameter(CoupleConnectScreenPreviewProvider::class) data: CoupleConnectState
+) {
+    CaramelTheme {
+        CoupleConnectScreen(
+            state = data,
+            onIntent = { }
+        )
+    }
+}

--- a/feature/couple/connect/src/androidMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectScreenPreviewData.kt
+++ b/feature/couple/connect/src/androidMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectScreenPreviewData.kt
@@ -1,0 +1,17 @@
+package com.whatever.caramel.feature.couple.connect
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.whatever.caramel.feature.couple.connect.mvi.CoupleConnectState
+
+internal class CoupleConnectScreenPreviewProvider :
+    PreviewParameterProvider<CoupleConnectState> {
+    override val values: Sequence<CoupleConnectState> = sequenceOf(
+        CoupleConnectState(
+            invitationCode = "코드값이 있을때"
+        ),
+        CoupleConnectState(
+            invitationCode = "" // empty 상태 일 때
+        ),
+    )
+
+}

--- a/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectScreen.kt
+++ b/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectScreen.kt
@@ -49,7 +49,8 @@ internal fun CoupleConnectScreen(
                                 indication = null
                             ),
                         painter = painterResource(resource = Resources.Icon.ic_arrow_left_24),
-                        contentDescription = null
+                        contentDescription = null,
+                        tint = CaramelTheme.color.icon.primary
                     )
                 }
             )

--- a/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectScreen.kt
+++ b/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectScreen.kt
@@ -1,51 +1,64 @@
 package com.whatever.caramel.feature.couple.connect
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.sp
+import com.whatever.caramel.core.designsystem.components.CaramelTopBar
+import com.whatever.caramel.core.designsystem.foundations.Resources
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.feature.couple.connect.components.CoupleConnectBottomBar
+import com.whatever.caramel.feature.couple.connect.components.CoupleConnectContents
 import com.whatever.caramel.feature.couple.connect.mvi.CoupleConnectIntent
 import com.whatever.caramel.feature.couple.connect.mvi.CoupleConnectState
+import org.jetbrains.compose.resources.painterResource
 
 @Composable
 internal fun CoupleConnectScreen(
     state: CoupleConnectState,
     onIntent: (CoupleConnectIntent) -> Unit
 ) {
-    Box(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Button(
-            modifier = Modifier.align(alignment = Alignment.TopStart),
-            onClick = { onIntent(CoupleConnectIntent.ClickBackButton) }
-        ) {
-            Text(
-                text = "뒤로가기",
-                fontSize = 12.sp
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        containerColor = CaramelTheme.color.background.primary,
+        bottomBar = {
+            CoupleConnectBottomBar(
+                modifier = Modifier
+                    .navigationBarsPadding()
+                    .imePadding(),
+                buttonEnabled = state.isButtonEnabled,
+                buttonText = "연결하기",
+                onClickButton = { onIntent(CoupleConnectIntent.ClickConnectButton) }
+            )
+        },
+        topBar = {
+            CaramelTopBar(
+                modifier = Modifier.systemBarsPadding(),
+                leadingIcon = {
+                    Icon(
+                        modifier = Modifier
+                            .clickable(
+                                onClick = { onIntent(CoupleConnectIntent.ClickBackButton) },
+                                interactionSource = null,
+                                indication = null
+                            ),
+                        painter = painterResource(resource = Resources.Icon.ic_arrow_left_24),
+                        contentDescription = null
+                    )
+                }
             )
         }
-
-        Text(
-            modifier = Modifier.align(alignment = Alignment.Center),
-            text = "코드 입력 화면 입니다.",
-            fontSize = 32.sp
+    ) { innerPadding ->
+        CoupleConnectContents(
+            modifier = Modifier.padding(paddingValues = innerPadding),
+            code = state.invitationCode,
+            onCodeChange = { code -> onIntent(CoupleConnectIntent.ChangeInvitationCode(code)) }
         )
-
-        Button(
-            modifier = Modifier
-                .fillMaxWidth()
-                .align(alignment = Alignment.BottomCenter),
-            onClick = { onIntent(CoupleConnectIntent.ClickConnectButton) }
-        ) {
-            Text(
-                text = "연결하기",
-                fontSize = 12.sp
-            )
-        }
     }
 }

--- a/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectViewModel.kt
+++ b/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectViewModel.kt
@@ -1,12 +1,14 @@
 package com.whatever.caramel.feature.couple.connect
 
 import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.domain.usecase.couple.ConnectCoupleUseCase
 import com.whatever.caramel.core.viewmodel.BaseViewModel
 import com.whatever.caramel.feature.couple.connect.mvi.CoupleConnectIntent
 import com.whatever.caramel.feature.couple.connect.mvi.CoupleConnectSideEffect
 import com.whatever.caramel.feature.couple.connect.mvi.CoupleConnectState
 
 class CoupleConnectViewModel(
+    private val connectCoupleUseCase: ConnectCoupleUseCase,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<CoupleConnectState, CoupleConnectSideEffect, CoupleConnectIntent>(savedStateHandle) {
 
@@ -16,8 +18,24 @@ class CoupleConnectViewModel(
 
     override suspend fun handleIntent(intent: CoupleConnectIntent) {
         when (intent) {
-            is CoupleConnectIntent.ClickConnectButton -> postSideEffect(CoupleConnectSideEffect.NavigateToMain)
+            is CoupleConnectIntent.ClickConnectButton -> connectCouple()
             is CoupleConnectIntent.ClickBackButton -> postSideEffect(CoupleConnectSideEffect.NavigateToInviteCouple)
+            is CoupleConnectIntent.ChangeInvitationCode -> changeInvitationCode(code = intent.invitationCode)
+        }
+    }
+
+    private suspend fun connectCouple() {
+        launch {
+            connectCoupleUseCase(invitationCode = currentState.invitationCode)
+            postSideEffect(CoupleConnectSideEffect.NavigateToMain)
+        }
+    }
+
+    private fun changeInvitationCode(code: String) {
+        reduce {
+            copy(
+                invitationCode = code
+            )
         }
     }
 

--- a/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/components/BottomBar.kt
+++ b/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/components/BottomBar.kt
@@ -38,9 +38,9 @@ internal fun CoupleConnectBottomBar(
     Box(
         modifier = modifier
             .padding(
-                start = 20.dp,
-                end = 20.dp,
-                bottom = 20.dp
+                start = CaramelTheme.spacing.xl,
+                end = CaramelTheme.spacing.xl,
+                bottom = CaramelTheme.spacing.xl,
             ),
         contentAlignment = Alignment.Center
     ) {

--- a/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/components/BottomBar.kt
+++ b/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/components/BottomBar.kt
@@ -1,0 +1,70 @@
+package com.whatever.caramel.feature.couple.connect.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+
+@Composable
+internal fun CoupleConnectBottomBar(
+    modifier: Modifier = Modifier,
+    buttonEnabled: Boolean,
+    buttonText: String,
+    onClickButton: () -> Unit
+) {
+    val buttonShape = CaramelTheme.shape.xl
+    val buttonBackgroundColor = if (buttonEnabled) {
+        CaramelTheme.color.fill.brand
+    } else {
+        CaramelTheme.color.fill.disabledPrimary
+    }
+    val textColor = if (buttonEnabled) {
+        CaramelTheme.color.text.inverse
+    } else {
+        CaramelTheme.color.text.disabledPrimary
+    }
+
+    Box(
+        modifier = modifier
+            .padding(
+                start = 20.dp,
+                end = 20.dp,
+                bottom = 20.dp
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Row(
+            modifier = Modifier
+                .height(height = 50.dp)
+                .fillMaxWidth()
+                .background(
+                    color = buttonBackgroundColor,
+                    shape = buttonShape
+                )
+                .clip(shape = buttonShape)
+                .clickable(
+                    enabled = buttonEnabled,
+                    onClick = onClickButton
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = buttonText,
+                style = CaramelTheme.typography.body1.bold,
+                color = textColor
+            )
+        }
+    }
+}

--- a/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/components/Content.kt
+++ b/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/components/Content.kt
@@ -1,0 +1,100 @@
+package com.whatever.caramel.feature.couple.connect.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+
+@Composable
+internal fun CoupleConnectContents(
+    modifier: Modifier = Modifier,
+    code: String,
+    onCodeChange: (String) -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "받은 초대 코드를\n입력해 주세요",
+            style = CaramelTheme.typography.heading1,
+            color = CaramelTheme.color.text.primary,
+            textAlign = TextAlign.Center
+        )
+
+        BasicTextField(
+            value = code,
+            onValueChange = onCodeChange,
+            cursorBrush = SolidColor(CaramelTheme.color.fill.brand),
+            textStyle = CaramelTheme.typography.heading2.copy(
+                color = CaramelTheme.color.text.primary,
+                textAlign = if (code.isNotEmpty()) {
+                    TextAlign.Center
+                } else {
+                    TextAlign.Start
+                }
+            ),
+            singleLine = true,
+        ) { innerTextField ->
+            SubcomposeLayout { constraints ->
+                val placeHolderPlaceable = subcompose("placeHolder") {
+                    PlaceHolder()
+                }.first().measure(constraints)
+
+                val placeHolderWidth = placeHolderPlaceable.width
+
+                val decorationBox = subcompose("decorationBox") {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .then(
+                                    if (code.isNotEmpty()) {
+                                        Modifier
+                                    } else {
+                                        Modifier.width(width = placeHolderWidth.toDp())
+                                    }
+                                ),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            innerTextField.invoke()
+
+                            if (code.isEmpty()) {
+                                PlaceHolder()
+                            }
+                        }
+                    }
+                }.first().measure(constraints)
+
+                layout(decorationBox.width, decorationBox.height) {
+                    decorationBox.placeRelative(0, 0)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlaceHolder() {
+    Text(
+        text = "코드 입력",
+        style = CaramelTheme.typography.heading2,
+        color = CaramelTheme.color.text.placeholder
+    )
+}

--- a/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/mvi/CoupleConnectIntent.kt
+++ b/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/mvi/CoupleConnectIntent.kt
@@ -8,4 +8,6 @@ sealed interface CoupleConnectIntent : UiIntent {
 
     data object ClickBackButton : CoupleConnectIntent
 
+    data class ChangeInvitationCode(val invitationCode: String) : CoupleConnectIntent
+
 }

--- a/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/mvi/CoupleConnectState.kt
+++ b/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/mvi/CoupleConnectState.kt
@@ -3,5 +3,10 @@ package com.whatever.caramel.feature.couple.connect.mvi
 import com.whatever.caramel.core.viewmodel.UiState
 
 data class CoupleConnectState(
-    val test: String = ""
-) : UiState
+    val invitationCode: String = "",
+) : UiState {
+
+    val isButtonEnabled: Boolean
+        get() = invitationCode.isNotEmpty()
+    
+}

--- a/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/navigation/CoupleConnectNavigation.kt
+++ b/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/navigation/CoupleConnectNavigation.kt
@@ -2,7 +2,7 @@ package com.whatever.caramel.feature.couple.connect.navigation
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import androidx.navigation.NavOptions
+import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.compose.composable
 import com.whatever.caramel.feature.couple.connect.CoupleConnectRoute
 import kotlinx.serialization.Serializable
@@ -10,11 +10,10 @@ import kotlinx.serialization.Serializable
 @Serializable
 data object ConnectCoupleRoute
 
-fun NavHostController.navigateToConnectCouple(navOptions: NavOptions? = null) {
-    navigate(
-        route = ConnectCoupleRoute,
-        navOptions = navOptions
-    )
+fun NavHostController.navigateToConnectCouple(builder: NavOptionsBuilder.() -> Unit = {}) {
+    navigate(route = ConnectCoupleRoute) {
+        builder()
+    }
 }
 
 fun NavGraphBuilder.connectCoupleScreen(

--- a/feature/couple/invite/src/commonMain/kotlin/com/whatever/caramel/feature/copule/invite/navigation/CoupleNavigation.kt
+++ b/feature/couple/invite/src/commonMain/kotlin/com/whatever/caramel/feature/copule/invite/navigation/CoupleNavigation.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data object CoupleInviteRote
 
-fun NavController.navigateToCoupleInvite(builder: NavOptionsBuilder.() -> Unit = {}) {
+fun NavController.navigateToInviteCouple(builder: NavOptionsBuilder.() -> Unit = {}) {
     navigate(route = CoupleInviteRote) {
         popUpTo(graph.id)
         builder()

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/navigation/ProfileNavigation.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/navigation/ProfileNavigation.kt
@@ -2,7 +2,7 @@ package com.whatever.caramel.feature.profile.create.navigation
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavOptions
+import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.compose.composable
 import com.whatever.caramel.feature.profile.create.ProfileCreateRoute
 import kotlinx.serialization.Serializable
@@ -10,11 +10,10 @@ import kotlinx.serialization.Serializable
 @Serializable
 data object ProfileCreateRoute
 
-fun NavController.navigateToCreateProfile(navOptions: NavOptions? = null) {
-    navigate(
-        route = ProfileCreateRoute,
-        navOptions = navOptions
-    )
+fun NavController.navigateToCreateProfile(builder: NavOptionsBuilder.() -> Unit = {}) {
+    navigate(route = ProfileCreateRoute) {
+        builder()
+    }
 }
 
 fun NavGraphBuilder.createProfileScreen(

--- a/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/SplashRoute.kt
+++ b/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/SplashRoute.kt
@@ -13,7 +13,7 @@ internal fun SplashRoute(
     navigateToLogin: () -> Unit,
     navigateToMain: () -> Unit,
     navigateToCreateProfile: () -> Unit,
-    navigateToConnectCouple: () -> Unit,
+    navigateToInviteCouple: () -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
@@ -22,8 +22,8 @@ internal fun SplashRoute(
             when (sideEffect) {
                 is SplashSideEffect.NavigateToLogin -> navigateToLogin()
                 is SplashSideEffect.NavigateToMain -> navigateToMain()
-                SplashSideEffect.NavigateToCreateProfile -> navigateToCreateProfile()
-                SplashSideEffect.NavigateToInviteCouple -> navigateToConnectCouple()
+                is SplashSideEffect.NavigateToCreateProfile -> navigateToCreateProfile()
+                is SplashSideEffect.NavigateToInviteCouple -> navigateToInviteCouple()
             }
         }
     }

--- a/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/navigation/SplashNavigation.kt
+++ b/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/navigation/SplashNavigation.kt
@@ -12,14 +12,14 @@ fun NavGraphBuilder.splashScreen(
     navigateToLogin: () -> Unit,
     navigateToMain: () -> Unit,
     navigateToCreateProfile: () -> Unit,
-    navigateToConnectCouple : () -> Unit
+    navigateToInviteCouple : () -> Unit
 ) {
     composable<SplashRoute>() {
         SplashRoute(
             navigateToLogin = navigateToLogin,
             navigateToMain = navigateToMain,
             navigateToCreateProfile = navigateToCreateProfile,
-            navigateToConnectCouple = navigateToConnectCouple
+            navigateToInviteCouple = navigateToInviteCouple
         )
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closed #110 

## 작업한 내용
- 커플 연결 화면 구현
- 커플 연결 로직 구현

## PR 포인트
- SubComposeLayout을 활용한 BasicTextField의 PlaceHolder와 cursor 위치 설정
  - 디자인 요구사항이 cursor의 위치가 placeHolder의 시작점에 위치해 있어야 했습니다. BasicTextField의 innerTextField 너비를 조절할수 없기 때문에, innerTextField보다 너비가 작은 placeHolder를 Box의 `Alignment.Center`를 사용하여 자리를 잡게 될 경우 양 끝단의 길이가 남게되며 cursor의 위치가 요구사항을 충족하지 못하는 상황을 발생시킵니다. invitationCode의 상태가 empty일 경우 placeHolder 너비 만큼의 Box 레이아웃 길이를 강제로 적용하고, notEmpty일 경우 fillMaxWidth를 적용시켜 요구사항을 충족시킵니다.

> Box의 `Alignment.Center`를 사용했을 때 placeHolder의 길이와 innerTextField의 크기 차이 (파란색 상자가 innerTextField)
<img src="https://github.com/user-attachments/assets/36330bbd-a679-4085-bd45-fdb74c000fea" width=250 height=500/>

```
BasicTextField(
  ...
) { innerTextField ->
  Box(
    modifier = Modifier.fillMaxSize(),
    contentAlignment = Alignment.Center
  ) {
    Box(contentAlignment = Alignment.Center) {
        innerTextField.invoke()
    
        if (code.isEmpty()) {
            Text(
              text = "코드 연결",
              style = CaramelTheme.typography.heading2,
              color = CaramelTheme.color.text.placeholder
            )
        }
    }
}
```
