### PR TITLE
[Feat] 홈 화면 및 CaramelButton 구현

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Button.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Button.kt
@@ -1,0 +1,86 @@
+package com.whatever.caramel.core.designsystem.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+
+enum class CaramelButtonType {
+    Enabled1,
+    Enabled2,
+    Disabled,
+    ;
+}
+
+enum class CaramelButtonSize {
+    Large,
+    Medium,
+    Small,
+    ;
+}
+
+@Composable
+fun CaramelButton(
+    buttonType: CaramelButtonType,
+    buttonSize: CaramelButtonSize,
+    modifier: Modifier = Modifier,
+    text: String,
+    onClick: () -> Unit
+) {
+    val buttonHeight = when (buttonSize) {
+        CaramelButtonSize.Large -> 50.dp
+        CaramelButtonSize.Medium -> 42.dp
+        CaramelButtonSize.Small -> 32.dp
+    }
+    val buttonBackgroundColor = when (buttonType) {
+        CaramelButtonType.Enabled1 -> CaramelTheme.color.fill.brand
+        CaramelButtonType.Enabled2 -> CaramelTheme.color.fill.quinary
+        CaramelButtonType.Disabled -> CaramelTheme.color.fill.disabledPrimary
+    }
+    val buttonShape = when (buttonSize) {
+        CaramelButtonSize.Large -> CaramelTheme.shape.xl
+        CaramelButtonSize.Medium -> CaramelTheme.shape.l
+        CaramelButtonSize.Small -> CaramelTheme.shape.s
+    }
+
+    val textColor = when (buttonType) {
+        CaramelButtonType.Enabled1 -> CaramelTheme.color.text.inverse
+        CaramelButtonType.Enabled2 -> CaramelTheme.color.text.brand
+        CaramelButtonType.Disabled -> CaramelTheme.color.text.disabledPrimary
+    }
+    val textStyle = when (buttonSize) {
+        CaramelButtonSize.Large -> CaramelTheme.typography.body1.bold
+        CaramelButtonSize.Medium -> CaramelTheme.typography.body3.bold
+        CaramelButtonSize.Small -> CaramelTheme.typography.label1.bold
+    }
+
+    Box(
+        modifier = modifier
+            .height(height = buttonHeight)
+            .background(
+                color = buttonBackgroundColor,
+                shape = buttonShape
+            )
+            .clip(shape = buttonShape)
+            .clickable(
+                enabled = buttonType != CaramelButtonType.Disabled,
+                onClick = onClick
+            )
+            .padding(horizontal = CaramelTheme.spacing.l),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            style = textStyle,
+            color = textColor
+        )
+    }
+}

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Button.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Button.kt
@@ -47,7 +47,7 @@ fun CaramelButton(
     }
     val buttonShape = when (buttonSize) {
         CaramelButtonSize.Large -> CaramelTheme.shape.xl
-        CaramelButtonSize.Medium -> CaramelTheme.shape.l
+        CaramelButtonSize.Medium -> CaramelTheme.shape.xl
         CaramelButtonSize.Small -> CaramelTheme.shape.s
     }
 

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
             implementation(libs.androidx.lifecycle.runtime.compose)
 
             implementation(libs.jetbrains.compose.navigation)
+            implementation(libs.kotlinx.collections.immutable)
         }
     }
 }

--- a/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreview.kt
+++ b/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreview.kt
@@ -1,0 +1,20 @@
+package com.whatever.caramel.feature.home
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.feature.home.mvi.HomeState
+
+@Preview
+@Composable
+private fun HomeScreenPreview(
+    @PreviewParameter(HoeScreenPreviewProvider::class) data: HomeState
+) {
+    CaramelTheme {
+        HomeScreen(
+            state = data,
+            onIntent = {}
+        )
+    }
+}

--- a/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreviewData.kt
+++ b/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreviewData.kt
@@ -9,56 +9,50 @@ internal class HoeScreenPreviewProvider :
     override val values: Sequence<HomeState> = sequenceOf(
         HomeState(
             daysTogether = 0,
-            savedShareMessage = "",
+            shareMessage = "",
             todos = emptyList(),
             isShowBottomSheet = true,
             isLoading = false,
-            bottomSheetMessage = "",
             isSetAnniversary = false
         ),
         HomeState(
             daysTogether = 0,
-            savedShareMessage = "",
+            shareMessage = "",
             todos = emptyList(),
             isShowBottomSheet = false,
             isLoading = false,
-            bottomSheetMessage = "",
             isSetAnniversary = false
         ),
         HomeState(
             daysTogether = 1120,
-            savedShareMessage = "내일 여기서 만나",
+            shareMessage = "내일 여기서 만나",
             todos = emptyList(),
             isShowBottomSheet = false,
             isLoading = false,
-            bottomSheetMessage = "내일 여기서 만나",
             isSetAnniversary = true
         ),
         HomeState(
             daysTogether = 1120,
-            savedShareMessage = "내일 여기서 만나",
+            shareMessage = "내일 여기서 만나",
             todos = listOf(TodoState(id = 1, title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다.")),
             isShowBottomSheet = false,
             isLoading = false,
-            bottomSheetMessage = "내일 여기서 만나",
             isSetAnniversary = true
         ),
         HomeState(
             daysTogether = 1120,
-            savedShareMessage = "내일 여기서 만나",
+            shareMessage = "내일 여기서 만나",
             todos = (0..7).map { TodoState(it.toLong(), "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다.") },
             isShowBottomSheet = false,
             isLoading = false,
-            bottomSheetMessage = "내일 여기서 만나",
             isSetAnniversary = true
         ),
         HomeState(
             daysTogether = 1120,
-            savedShareMessage = "내일 여기서 만나",
+            shareMessage = "내일 여기서 만나",
             todos = (0..7).map { TodoState(it.toLong(), "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다.") },
             isShowBottomSheet = false,
             isLoading = true,
-            bottomSheetMessage = "내일 여기서 만나",
             isSetAnniversary = true
         ),
     )

--- a/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreviewData.kt
+++ b/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreviewData.kt
@@ -1,0 +1,65 @@
+package com.whatever.caramel.feature.home
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.whatever.caramel.feature.home.mvi.HomeState
+import com.whatever.caramel.feature.home.mvi.TodoState
+
+internal class HoeScreenPreviewProvider :
+    PreviewParameterProvider<HomeState> {
+    override val values: Sequence<HomeState> = sequenceOf(
+        HomeState(
+            daysTogether = 0,
+            savedShareMessage = "",
+            todos = emptyList(),
+            isShowBottomSheet = true,
+            isLoading = false,
+            bottomSheetMessage = "",
+            isSetAnniversary = false
+        ),
+        HomeState(
+            daysTogether = 0,
+            savedShareMessage = "",
+            todos = emptyList(),
+            isShowBottomSheet = false,
+            isLoading = false,
+            bottomSheetMessage = "",
+            isSetAnniversary = false
+        ),
+        HomeState(
+            daysTogether = 1120,
+            savedShareMessage = "내일 여기서 만나",
+            todos = emptyList(),
+            isShowBottomSheet = false,
+            isLoading = false,
+            bottomSheetMessage = "내일 여기서 만나",
+            isSetAnniversary = true
+        ),
+        HomeState(
+            daysTogether = 1120,
+            savedShareMessage = "내일 여기서 만나",
+            todos = listOf(TodoState(id = 1, title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다.")),
+            isShowBottomSheet = false,
+            isLoading = false,
+            bottomSheetMessage = "내일 여기서 만나",
+            isSetAnniversary = true
+        ),
+        HomeState(
+            daysTogether = 1120,
+            savedShareMessage = "내일 여기서 만나",
+            todos = (0..7).map { TodoState(it.toLong(), "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다.") },
+            isShowBottomSheet = false,
+            isLoading = false,
+            bottomSheetMessage = "내일 여기서 만나",
+            isSetAnniversary = true
+        ),
+        HomeState(
+            daysTogether = 1120,
+            savedShareMessage = "내일 여기서 만나",
+            todos = (0..7).map { TodoState(it.toLong(), "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다.") },
+            isShowBottomSheet = false,
+            isLoading = true,
+            bottomSheetMessage = "내일 여기서 만나",
+            isSetAnniversary = true
+        ),
+    )
+}

--- a/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreviewData.kt
+++ b/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreviewData.kt
@@ -34,7 +34,7 @@ internal class HoeScreenPreviewProvider :
         HomeState(
             daysTogether = 1120,
             shareMessage = "내일 여기서 만나",
-            todos = listOf(TodoState(id = 1, title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다.")),
+            todos = listOf(TodoState(id = 1, title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?")),
             isShowBottomSheet = false,
             isLoading = false,
             isSetAnniversary = true
@@ -42,7 +42,7 @@ internal class HoeScreenPreviewProvider :
         HomeState(
             daysTogether = 1120,
             shareMessage = "내일 여기서 만나",
-            todos = (0..7).map { TodoState(it.toLong(), "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다.") },
+            todos = (0..7).map { TodoState(it.toLong(), "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?") },
             isShowBottomSheet = false,
             isLoading = false,
             isSetAnniversary = true
@@ -50,7 +50,7 @@ internal class HoeScreenPreviewProvider :
         HomeState(
             daysTogether = 1120,
             shareMessage = "내일 여기서 만나",
-            todos = (0..7).map { TodoState(it.toLong(), "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다.") },
+            todos = (0..7).map { TodoState(it.toLong(), "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?") },
             isShowBottomSheet = false,
             isLoading = true,
             isSetAnniversary = true

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeRoute.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeRoute.kt
@@ -22,9 +22,9 @@ internal fun HomeRoute(
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is HomeSideEffect.NavigateToSetting -> navigateToSetting()
-                is HomeSideEffect.NavigateToStartedCoupleDay -> navigateToStaredCoupleDay()
-                is HomeSideEffect.NavigateToCreateTodo -> navigateToCreateTodo()
-                is HomeSideEffect.NavigateToTodoDetail -> navigateToTodoDetail()
+                is HomeSideEffect.NavigateToCreateContent -> navigateToCreateTodo()
+                is HomeSideEffect.NavigateToContentDetail -> navigateToTodoDetail()
+                is HomeSideEffect.NavigateToEditAnniversary -> navigateToStaredCoupleDay()
             }
         }
     }

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeScreen.kt
@@ -1,9 +1,11 @@
 package com.whatever.caramel.feature.home
 
+import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -12,7 +14,9 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import com.whatever.caramel.core.designsystem.components.CaramelTopBar
 import com.whatever.caramel.core.designsystem.foundations.Resources
@@ -25,6 +29,7 @@ import com.whatever.caramel.feature.home.mvi.HomeIntent
 import com.whatever.caramel.feature.home.mvi.HomeState
 import kotlinx.collections.immutable.toImmutableList
 import org.jetbrains.compose.resources.painterResource
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -32,7 +37,6 @@ internal fun HomeScreen(
     state: HomeState,
     onIntent: (HomeIntent) -> Unit
 ) {
-    val pullToRefreshState = rememberPullToRefreshState()
     val sheetState = rememberStandardBottomSheetState(
         initialValue = SheetValue.PartiallyExpanded,
         skipHiddenState = false
@@ -74,13 +78,31 @@ internal fun HomeScreen(
             )
         }
     ) { innerPadding ->
+        val pullToRefreshState = rememberPullToRefreshState()
+        val lazyListState = rememberLazyListState()
+        val homeContentsOffset by animateIntAsState(
+            targetValue = when {
+                state.isLoading -> 250
+                pullToRefreshState.distanceFraction in 0f..1f -> (250 * pullToRefreshState.distanceFraction).roundToInt()
+                pullToRefreshState.distanceFraction > 1f -> (250 + ((pullToRefreshState.distanceFraction - 1f) * 1f) * 100).roundToInt()
+                else -> 0
+            }
+        )
+
         PullToRefreshBox(
             modifier = Modifier.padding(top = innerPadding.calculateTopPadding()),
             state = pullToRefreshState,
             isRefreshing = state.isLoading,
             onRefresh = { onIntent(HomeIntent.PullToRefresh) },
         ) {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
+            LazyColumn(
+                state = lazyListState,
+                userScrollEnabled = !state.isLoading,
+                overscrollEffect = null,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer { translationY = homeContentsOffset.toFloat() },
+            ) {
                 Header(
                     shareMessage = state.savedShareMessage,
                     daysTogether = state.daysTogether,

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeScreen.kt
@@ -51,11 +51,9 @@ internal fun HomeScreen(
                     end = CaramelTheme.spacing.xl
                 ),
             sheetState = sheetState,
-            shareMessage = state.bottomSheetMessage,
-            onChangeShareMessage = { message -> onIntent(HomeIntent.ChangeShareMessage(message = message)) },
+            initialShareMessage = state.shareMessage,
             onDismiss = { onIntent(HomeIntent.HideShareMessageEditBottomSheet) },
-            onClickClear = { onIntent(HomeIntent.ClearShareMessage) },
-            onClickSave = { onIntent(HomeIntent.SaveShareMessage) }
+            onClickSave = { newShareMessage -> onIntent(HomeIntent.SaveShareMessage(newShareMessage = newShareMessage)) }
         )
     }
 
@@ -104,7 +102,7 @@ internal fun HomeScreen(
                     .graphicsLayer { translationY = homeContentsOffset.toFloat() },
             ) {
                 Header(
-                    shareMessage = state.savedShareMessage,
+                    shareMessage = state.shareMessage,
                     daysTogether = state.daysTogether,
                     onClickShareMessage = { onIntent(HomeIntent.ShowShareMessageEditBottomSheet) }
                 )

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
@@ -5,6 +5,8 @@ import com.whatever.caramel.core.viewmodel.BaseViewModel
 import com.whatever.caramel.feature.home.mvi.HomeIntent
 import com.whatever.caramel.feature.home.mvi.HomeSideEffect
 import com.whatever.caramel.feature.home.mvi.HomeState
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.delay
 
 class HomeViewModel(
     savedStateHandle: SavedStateHandle
@@ -16,10 +18,74 @@ class HomeViewModel(
 
     override suspend fun handleIntent(intent: HomeIntent) {
         when (intent) {
-            is HomeIntent.ClickTodoItem -> postSideEffect(HomeSideEffect.NavigateToTodoDetail)
-            is HomeIntent.ClickCreateTodoItem -> postSideEffect(HomeSideEffect.NavigateToCreateTodo)
-            is HomeIntent.ClickStartedCoupleDayButton -> postSideEffect(HomeSideEffect.NavigateToStartedCoupleDay)
+            is HomeIntent.ClickAnniversaryNudgeCard -> postSideEffect(HomeSideEffect.NavigateToEditAnniversary)
             is HomeIntent.ClickSettingButton -> postSideEffect(HomeSideEffect.NavigateToSetting)
+            is HomeIntent.ClickTodoContent -> postSideEffect(HomeSideEffect.NavigateToContentDetail(contentId = intent.todoContentId))
+            is HomeIntent.CreateTodoContent -> postSideEffect(HomeSideEffect.NavigateToCreateContent)
+            is HomeIntent.ClearShareMessage -> clearShareMessage()
+            is HomeIntent.SaveShareMessage -> saveShareMessage()
+            is HomeIntent.ShowShareMessageEditBottomSheet -> showBottomSheet()
+            is HomeIntent.HideShareMessageEditBottomSheet -> hideBottomSheet()
+            is HomeIntent.PullToRefresh -> refreshHomeData()
+            is HomeIntent.ChangeShareMessage -> changeShareMessage(message = intent.message)
+        }
+    }
+
+    private suspend fun saveShareMessage() {
+        launch {
+            val message = currentState.bottomSheetMessage
+            // @ham2174 TODO : 기억할 말 저장 유스케이스 연결
+            // 저장 성공 시
+            reduce {
+                copy(
+                    savedShareMessage = message,
+                    isShowBottomSheet = false
+                )
+            }
+        }
+    }
+
+    private fun clearShareMessage() {
+        reduce {
+            copy(bottomSheetMessage = "")
+        }
+    }
+
+    private fun changeShareMessage(message: String) {
+        if (!message.contains("\n") && message.length <= 24) {
+            reduce {
+                copy(bottomSheetMessage = message)
+            }
+        }
+    }
+
+    private suspend fun refreshHomeData() {
+        launch {
+            reduce { copy(isLoading = true) }
+
+            // @ham2174 TODO : 홈 데이터 업데이트하기
+            // 기억할 말 가져오기
+            // 만난 날짜 가져오기
+            // 오늘 일정 가져오기
+            Napier.d { "데이터 업데이트" }
+            delay(2000L)
+
+            reduce { copy(isLoading = false) }
+        }
+    }
+
+    private fun showBottomSheet() {
+        reduce {
+            copy(isShowBottomSheet = true)
+        }
+    }
+
+    private fun hideBottomSheet() {
+        reduce {
+            copy(
+                isShowBottomSheet = false,
+                bottomSheetMessage = savedShareMessage
+            )
         }
     }
 

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
@@ -22,39 +22,22 @@ class HomeViewModel(
             is HomeIntent.ClickSettingButton -> postSideEffect(HomeSideEffect.NavigateToSetting)
             is HomeIntent.ClickTodoContent -> postSideEffect(HomeSideEffect.NavigateToContentDetail(contentId = intent.todoContentId))
             is HomeIntent.CreateTodoContent -> postSideEffect(HomeSideEffect.NavigateToCreateContent)
-            is HomeIntent.ClearShareMessage -> clearShareMessage()
-            is HomeIntent.SaveShareMessage -> saveShareMessage()
+            is HomeIntent.SaveShareMessage -> saveShareMessage(newShareMessage = intent.newShareMessage)
             is HomeIntent.ShowShareMessageEditBottomSheet -> showBottomSheet()
             is HomeIntent.HideShareMessageEditBottomSheet -> hideBottomSheet()
             is HomeIntent.PullToRefresh -> refreshHomeData()
-            is HomeIntent.ChangeShareMessage -> changeShareMessage(message = intent.message)
         }
     }
 
-    private suspend fun saveShareMessage() {
+    private suspend fun saveShareMessage(newShareMessage: String) {
         launch {
-            val message = currentState.bottomSheetMessage
             // @ham2174 TODO : 기억할 말 저장 유스케이스 연결
             // 저장 성공 시
             reduce {
                 copy(
-                    savedShareMessage = message,
+                    shareMessage = newShareMessage,
                     isShowBottomSheet = false
                 )
-            }
-        }
-    }
-
-    private fun clearShareMessage() {
-        reduce {
-            copy(bottomSheetMessage = "")
-        }
-    }
-
-    private fun changeShareMessage(message: String) {
-        if (!message.contains("\n") && message.length <= 24) {
-            reduce {
-                copy(bottomSheetMessage = message)
             }
         }
     }
@@ -82,10 +65,7 @@ class HomeViewModel(
 
     private fun hideBottomSheet() {
         reduce {
-            copy(
-                isShowBottomSheet = false,
-                bottomSheetMessage = savedShareMessage
-            )
+            copy(isShowBottomSheet = false)
         }
     }
 

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/BottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/BottomSheet.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -48,7 +47,7 @@ internal fun ShareMessageBottomSheet(
     }
 
     ModalBottomSheet(
-        modifier = modifier.imePadding(),
+        modifier = modifier,
         onDismissRequest = onDismiss,
         dragHandle = null,
         containerColor = CaramelTheme.color.background.tertiary,

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/BottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/BottomSheet.kt
@@ -1,0 +1,143 @@
+package com.whatever.caramel.feature.home.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.unit.dp
+import com.whatever.caramel.core.designsystem.components.CaramelButton
+import com.whatever.caramel.core.designsystem.components.CaramelButtonSize
+import com.whatever.caramel.core.designsystem.components.CaramelButtonType
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ShareMessageBottomSheet(
+    modifier: Modifier = Modifier,
+    bottomSheetContentModifier: Modifier = Modifier,
+    shareMessage: String,
+    sheetState: SheetState,
+    onDismiss: () -> Unit,
+    onChangeShareMessage: (String) -> Unit,
+    onClickSave: () -> Unit,
+    onClickClear: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    ModalBottomSheet(
+        modifier = modifier.imePadding(),
+        onDismissRequest = onDismiss,
+        dragHandle = null,
+        containerColor = CaramelTheme.color.background.tertiary,
+        scrimColor = CaramelTheme.color.alpha.primary,
+        sheetState = sheetState,
+    ) {
+        BottomSheetContent(
+            modifier = bottomSheetContentModifier,
+            shareMessage = shareMessage,
+            focusRequester = focusRequester,
+            onChangeShareMessage = onChangeShareMessage,
+            onClickSave = {
+                keyboardController?.hide()
+                onClickSave()
+            },
+            onClickClear = onClickClear
+        )
+    }
+}
+
+@Composable
+private fun BottomSheetContent(
+    modifier: Modifier = Modifier,
+    shareMessage: String,
+    focusRequester: FocusRequester,
+    onChangeShareMessage: (String) -> Unit,
+    onClickSave: () -> Unit,
+    onClickClear: () -> Unit
+) {
+    Column(modifier = modifier) {
+        BasicTextField(
+            modifier = Modifier.focusRequester(focusRequester = focusRequester),
+            value = shareMessage,
+            onValueChange = { newValue -> onChangeShareMessage(newValue) },
+            minLines = 1,
+            maxLines = 2,
+            textStyle = CaramelTheme.typography.heading3.copy(
+                color = CaramelTheme.color.text.primary
+            ),
+            cursorBrush = SolidColor(CaramelTheme.color.fill.brand)
+        ) { innerTextField ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(height = 52.dp),
+            ) {
+                innerTextField()
+
+                if (shareMessage.isEmpty()) {
+                    Text(
+                        text = "기억하고 싶은 말을 남겨보세요",
+                        style = CaramelTheme.typography.heading3,
+                        color = CaramelTheme.color.text.placeholder
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(height = CaramelTheme.spacing.l))
+
+        Text(
+            text = "${shareMessage.length}/24",
+            style = CaramelTheme.typography.body3.bold,
+            color = CaramelTheme.color.text.placeholder
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = CaramelTheme.spacing.xl),
+            horizontalArrangement = Arrangement.spacedBy(
+                space = CaramelTheme.spacing.m
+            )
+        ) {
+            CaramelButton(
+                modifier = Modifier.weight(1f),
+                buttonType = CaramelButtonType.Enabled2,
+                buttonSize = CaramelButtonSize.Large,
+                text = "비우기",
+                onClick = onClickClear
+            )
+
+            CaramelButton(
+                modifier = Modifier.weight(1f),
+                buttonType = CaramelButtonType.Enabled1,
+                buttonSize = CaramelButtonSize.Large,
+                text = "저장하기",
+                onClick = onClickSave
+            )
+        }
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Header.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Header.kt
@@ -1,0 +1,97 @@
+package com.whatever.caramel.feature.home.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.whatever.caramel.core.designsystem.foundations.Resources
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import org.jetbrains.compose.resources.painterResource
+
+internal fun LazyListScope.Header(
+    daysTogether: Int,
+    shareMessage: String,
+    onClickShareMessage: () -> Unit
+) {
+    item(key = "Header") {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    bottom = CaramelTheme.spacing.l,
+                    start = CaramelTheme.spacing.xl,
+                    end = CaramelTheme.spacing.xl,
+                ),
+            verticalArrangement = Arrangement.spacedBy(space = 2.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            val daysTogetherAnnotatedString = buildAnnotatedString {
+                withStyle(style = CaramelTheme.typography.heading1.toSpanStyle()) {
+                    append("우리가 만난지\n")
+                }
+                withStyle(style = CaramelTheme.typography.display.toSpanStyle()) {
+                    append("${daysTogether}일")
+                }
+            }
+
+            Text(
+                text = daysTogetherAnnotatedString,
+                textAlign = TextAlign.Center,
+                color = CaramelTheme.color.text.primary
+            )
+
+            val shareMessageAnnotatedString = buildAnnotatedString {
+                append(shareMessage.ifEmpty { "함께 기억할 말을 남겨보세요" })
+                append(" ")
+                appendInlineContent(id = "edit icon")
+            }
+            val inlineContentMap = mapOf(
+                "edit icon" to InlineTextContent(
+                    placeholder = Placeholder(
+                        width = 16.sp,
+                        height = 16.sp,
+                        placeholderVerticalAlign = PlaceholderVerticalAlign.Center
+                    ),
+                    children = {
+                        Icon(
+                            painter = painterResource(resource = Resources.Icon.ic_edit_16),
+                            contentDescription = null,
+                            tint = CaramelTheme.color.text.secondary
+                        )
+                    },
+                )
+            )
+
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        onClick = onClickShareMessage,
+                        interactionSource = null,
+                        indication = null
+                    )
+                    .padding(vertical = CaramelTheme.spacing.xs),
+                text = shareMessageAnnotatedString,
+                inlineContent = inlineContentMap,
+                color = CaramelTheme.color.text.secondary,
+                style = CaramelTheme.typography.body3.bold,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Header.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Header.kt
@@ -71,7 +71,7 @@ internal fun LazyListScope.Header(
                         Icon(
                             painter = painterResource(resource = Resources.Icon.ic_edit_16),
                             contentDescription = null,
-                            tint = CaramelTheme.color.text.secondary
+                            tint = CaramelTheme.color.icon.secondary
                         )
                     },
                 )

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Quiz.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Quiz.kt
@@ -1,0 +1,27 @@
+package com.whatever.caramel.feature.home.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+internal fun LazyListScope.Quiz(
+    
+) {
+    item(key = "Quiz") {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(height = 376.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "Quiz 예정"
+            )
+        }
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Todos.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Todos.kt
@@ -136,10 +136,13 @@ private fun TodoItem(
 ) {
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.SpaceBetween,
+        horizontalArrangement = Arrangement.spacedBy(
+            space = CaramelTheme.spacing.m
+        ),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
+            modifier = Modifier.weight(weight = 1f),
             text = title,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Todos.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Todos.kt
@@ -1,0 +1,219 @@
+package com.whatever.caramel.feature.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.whatever.caramel.core.designsystem.foundations.Resources
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.feature.home.mvi.TodoState
+import kotlinx.collections.immutable.ImmutableList
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.painterResource
+
+internal fun LazyListScope.Todo(
+    todoList: ImmutableList<TodoState>,
+    isSetAnniversary: Boolean,
+    onClickAnniversaryNudgeCard: () -> Unit,
+    onClickTodoItem: (todoContentId: Long) -> Unit,
+    onClickEmptyTodo: () -> Unit
+) {
+    item(key = "Todos") {
+        Column(
+            modifier = Modifier
+                .padding(
+                    start = CaramelTheme.spacing.xl,
+                    end = CaramelTheme.spacing.xl,
+                    bottom = CaramelTheme.spacing.xl,
+                ),
+            verticalArrangement = Arrangement.spacedBy(
+                space = CaramelTheme.spacing.s
+            )
+        ) {
+            if (!isSetAnniversary) {
+                NudgeCard(
+                    text = "커플 시작일을 입력해주세요.\n기념일을 바로 알 수 있어요!",
+                    iconResource = Resources.Icon.ic_arrow_right_16,
+                    onClick = onClickAnniversaryNudgeCard
+                )
+            }
+
+            TodoList(
+                modifier = Modifier
+                    .background(
+                        color = CaramelTheme.color.fill.quaternary,
+                        shape = CaramelTheme.shape.l
+                    )
+                    .padding(
+                        bottom = CaramelTheme.spacing.m,
+                        top = CaramelTheme.spacing.l,
+                        start = CaramelTheme.spacing.l,
+                        end = CaramelTheme.spacing.l
+                    ),
+                todoList = todoList,
+                onClickTodoItem = onClickTodoItem,
+                onClickEmptyTodo = onClickEmptyTodo
+            )
+        }
+    }
+}
+
+@Composable
+private fun TodoList(
+    modifier: Modifier = Modifier,
+    todoList: ImmutableList<TodoState>,
+    onClickTodoItem: (todoContentId: Long) -> Unit,
+    onClickEmptyTodo: () -> Unit
+) {
+    Column(modifier = modifier) {
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = "오늘 일정",
+            style = CaramelTheme.typography.heading3,
+            color = CaramelTheme.color.text.primary
+        )
+
+        Spacer(modifier = Modifier.height(height = CaramelTheme.spacing.s))
+
+        if (todoList.isEmpty()) {
+            EmptyTodo(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        onClick = onClickEmptyTodo,
+                        interactionSource = null,
+                        indication = null
+                    )
+                    .padding(vertical = CaramelTheme.spacing.s),
+            )
+        } else {
+            todoList.forEachIndexed { index, todo ->
+                TodoItem(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(
+                            onClick = { onClickTodoItem(todo.id) },
+                            interactionSource = null,
+                            indication = null
+                        )
+                        .padding(
+                            vertical = CaramelTheme.spacing.s,
+                        ),
+                    title = todo.title
+                )
+
+                if (index < todoList.size - 1) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(vertical = CaramelTheme.spacing.xs),
+                        thickness = 1.dp,
+                        color = CaramelTheme.color.divider.tertiary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TodoItem(
+    modifier: Modifier = Modifier,
+    title: String,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = title,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = CaramelTheme.typography.body3.regular,
+            color = CaramelTheme.color.text.primary
+        )
+
+        Icon(
+            painter = painterResource(resource = Resources.Icon.ic_arrow_right_16),
+            tint = CaramelTheme.color.icon.tertiary,
+            contentDescription = null
+        )
+    }
+}
+
+@Composable
+private fun EmptyTodo(
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "오늘 할 일을 등록해 주세요",
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = CaramelTheme.typography.body3.regular,
+            color = CaramelTheme.color.text.placeholder
+        )
+
+        Icon(
+            painter = painterResource(resource = Resources.Icon.ic_plus_16),
+            tint = CaramelTheme.color.icon.tertiary,
+            contentDescription = null
+        )
+    }
+}
+
+@Composable
+private fun NudgeCard(
+    modifier: Modifier = Modifier,
+    text: String,
+    iconResource: DrawableResource,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = CaramelTheme.color.fill.quaternary,
+                shape = CaramelTheme.shape.l
+            )
+            .clip(shape = CaramelTheme.shape.l)
+            .clickable(
+                onClick = onClick,
+                indication = null,
+                interactionSource = null
+            )
+            .padding(all = CaramelTheme.spacing.l),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = text,
+            style = CaramelTheme.typography.body3.bold,
+            color = CaramelTheme.color.text.primary
+        )
+
+        Icon(
+            painter = painterResource(resource = iconResource),
+            tint = CaramelTheme.color.icon.tertiary,
+            contentDescription = null,
+        )
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeIntent.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeIntent.kt
@@ -6,10 +6,22 @@ sealed interface HomeIntent : UiIntent {
 
     data object ClickSettingButton : HomeIntent
 
-    data object ClickStartedCoupleDayButton : HomeIntent
+    data object ShowShareMessageEditBottomSheet : HomeIntent
 
-    data object ClickCreateTodoItem : HomeIntent
+    data object HideShareMessageEditBottomSheet : HomeIntent
 
-    data object ClickTodoItem : HomeIntent
+    data object SaveShareMessage : HomeIntent
+
+    data object ClearShareMessage : HomeIntent
+
+    data object CreateTodoContent : HomeIntent
+
+    data class ClickTodoContent(val todoContentId: Long) : HomeIntent
+
+    data object PullToRefresh : HomeIntent
+
+    data class ChangeShareMessage(val message: String) : HomeIntent
+
+    data object ClickAnniversaryNudgeCard : HomeIntent
 
 }

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeIntent.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeIntent.kt
@@ -10,17 +10,13 @@ sealed interface HomeIntent : UiIntent {
 
     data object HideShareMessageEditBottomSheet : HomeIntent
 
-    data object SaveShareMessage : HomeIntent
-
-    data object ClearShareMessage : HomeIntent
+    data class SaveShareMessage(val newShareMessage: String) : HomeIntent
 
     data object CreateTodoContent : HomeIntent
 
     data class ClickTodoContent(val todoContentId: Long) : HomeIntent
 
     data object PullToRefresh : HomeIntent
-
-    data class ChangeShareMessage(val message: String) : HomeIntent
 
     data object ClickAnniversaryNudgeCard : HomeIntent
 

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeSideEffect.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeSideEffect.kt
@@ -6,10 +6,10 @@ sealed interface HomeSideEffect : UiSideEffect {
 
     data object NavigateToSetting : HomeSideEffect
 
-    data object NavigateToCreateTodo : HomeSideEffect
+    data object NavigateToCreateContent : HomeSideEffect
 
-    data object NavigateToTodoDetail : HomeSideEffect
+    data class NavigateToContentDetail(val contentId: Long) : HomeSideEffect
 
-    data object NavigateToStartedCoupleDay : HomeSideEffect
+    data object NavigateToEditAnniversary : HomeSideEffect
 
 }

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeState.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeState.kt
@@ -1,7 +1,20 @@
 package com.whatever.caramel.feature.home.mvi
 
+import androidx.compose.runtime.Immutable
 import com.whatever.caramel.core.viewmodel.UiState
 
 data class HomeState(
-    val text: String = ""
+    val daysTogether: Int = 0,
+    val savedShareMessage: String = "",
+    val bottomSheetMessage: String = "",
+    val todos: List<TodoState> = emptyList(),
+    val isSetAnniversary: Boolean = false,
+    val isShowBottomSheet: Boolean = false,
+    val isLoading: Boolean = false
 ) : UiState
+
+@Immutable
+data class TodoState(
+    val id: Long,
+    val title: String,
+)

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeState.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeState.kt
@@ -5,8 +5,7 @@ import com.whatever.caramel.core.viewmodel.UiState
 
 data class HomeState(
     val daysTogether: Int = 0,
-    val savedShareMessage: String = "",
-    val bottomSheetMessage: String = "",
+    val shareMessage: String = "",
     val todos: List<TodoState> = emptyList(),
     val isSetAnniversary: Boolean = false,
     val isShowBottomSheet: Boolean = false,

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@ kotlin.mpp.enableCInteropCommonization=true
 #Build target ignore
 kotlin.native.ignoreDisabledTargets=true
 kotlin.native.binary.bundleId=com.whatever.caramel
+kotlin.native.cacheKind=none
 
 #Android
 android.useAndroidX=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ kotlinx-date-time = "0.6.2"
 turbine = "1.2.0"
 mokkery = "2.7.2"
 animationCoreAndroid = "1.7.8"
+kotlinx-collections-immutable = "0.3.8"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -58,6 +59,7 @@ androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose-plugin" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 
 jetbrains-compose-navigation = { group = "org.jetbrains.androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinSerialization" }


### PR DESCRIPTION
## 관련 이슈
- closed #112 
- closed #114 
- closed #51 

## 작업한 내용
- HomeScreen
  - PullToRefresh UI 구현
  - 기억할 말 남기기 BottomSheet 구현
  - 오늘 일정 리스트 구현
  - HomeScreenPreview 구현
- Design-System
  - CaramelButton 구현
- Build-Gradle
  - `org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.8` 추가

## PR 포인트
- Immutable-Collections 추가
  - '일정 리스트'가 변경될 수 있는 리스트이므로 `ImmutableList`를 사용하여 Recomposition 성능 최적화를 진행합니다.
- 퀴즈 UI 미구현
  - FCM 기능이 우선순위로 올라옴에 따라, 퀴즈 UI 구현은 제외하고 구현하였습니다. 

## 미리보기
<img src="https://github.com/user-attachments/assets/d74ed343-0978-452e-9817-350e666f0743" width=700 height=500/>
<img src="https://github.com/user-attachments/assets/309e538c-754e-4da7-b528-943e00a1e447" width=700 height=500/>


