### PR TITLE
[Refactor] 설정 > 커플 정보 API 호출 시점 변경

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -12,6 +12,8 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.core.designsystem)
             implementation(projects.core.util)
+
+            api(libs.androidx.lifecycle.runtime.compose)
         }
     }
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
             implementation(projects.core.designsystem)
             implementation(projects.core.util)
 
-            api(libs.androidx.lifecycle.runtime.compose)
+            implementation(libs.androidx.lifecycle.runtime.compose)
         }
     }
 }

--- a/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/util/ObserveLifecycleEvent.kt
+++ b/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/util/ObserveLifecycleEvent.kt
@@ -1,4 +1,4 @@
-package com.whatever.caramel.feature.setting.util
+package com.whatever.caramel.core.ui.util
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -8,7 +8,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 
 @Composable
-fun OnLifecycleEvent(
+fun ObserveLifecycleEvent(
     lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
     onEvent: (Lifecycle.Event) -> Unit
 ) {

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingRoute.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingRoute.kt
@@ -7,8 +7,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.whatever.caramel.feature.setting.mvi.SettingIntent
 import com.whatever.caramel.feature.setting.mvi.SettingSideEffect
-import com.whatever.caramel.feature.setting.util.OnLifecycleEvent
-import io.github.aakira.napier.Napier
+import com.whatever.caramel.core.ui.util.ObserveLifecycleEvent
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -22,7 +21,7 @@ internal fun SettingRoute(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
-    OnLifecycleEvent { event ->
+    ObserveLifecycleEvent { event ->
         if (event == Lifecycle.Event.ON_START) {
             viewModel.intent(SettingIntent.RefreshCoupleData)
         }

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingRoute.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingRoute.kt
@@ -2,30 +2,28 @@ package com.whatever.caramel.feature.setting
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.whatever.caramel.feature.setting.mvi.SettingIntent
 import com.whatever.caramel.feature.setting.mvi.SettingSideEffect
+import com.whatever.caramel.feature.setting.util.OnLifecycleEvent
+import io.github.aakira.napier.Napier
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 internal fun SettingRoute(
     viewModel: SettingViewModel = koinViewModel(),
     navigateToHome: () -> Unit,
-    navigateToLogin : () -> Unit,
+    navigateToLogin: () -> Unit,
     navigateToEditCountDown: (Long) -> Unit,
     navigateToEditBirthday: (Long) -> Unit,
     navigateToEditNickName: (String) -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val lifecycleState by lifecycleOwner.lifecycle.currentStateFlow.collectAsState()
 
-    LaunchedEffect(lifecycleState) {
-        if (lifecycleState == Lifecycle.State.STARTED) {
+    OnLifecycleEvent { event ->
+        if (event == Lifecycle.Event.ON_START) {
             viewModel.intent(SettingIntent.RefreshCoupleData)
         }
     }

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/component/UserProfile.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/component/UserProfile.kt
@@ -53,7 +53,7 @@ internal fun SettingUserProfile(
             tint = Color.Unspecified
         )
 
-        Spacer(modifier = Modifier.padding(end = CaramelTheme.spacing.m))
+        Spacer(modifier = Modifier.size(size = CaramelTheme.spacing.m))
         Column(
             modifier = Modifier
                 .weight(1f),
@@ -109,7 +109,7 @@ internal fun SettingUserProfileSkeleton(
                 .size(50.dp)
                 .shimmer(shape = CaramelTheme.shape.l)
         )
-        Spacer(modifier = Modifier.padding(end = CaramelTheme.spacing.m))
+        Spacer(modifier = Modifier.size(size = CaramelTheme.spacing.m))
         Column(
             modifier = Modifier
                 .weight(1f),

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/util/OnLifecycleEvent.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/util/OnLifecycleEvent.kt
@@ -1,0 +1,24 @@
+package com.whatever.caramel.feature.setting.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+@Composable
+fun OnLifecycleEvent(
+    lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
+    onEvent: (Lifecycle.Event) -> Unit
+) {
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            onEvent(event)
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ org.gradle.configuration-cache=true
 #Kotlin
 kotlin.code.style=official
 kotlin.mpp.enableCInteropCommonization=true
+kotlin.native.cacheKind=none
 
 #Build target ignore
 kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
## 관련 이슈
- #116 

## 작업한 내용
- LifecycleEvent를 감지하는 OnLifecycleEvent 구현
- 설정에서 API 호출 시점을 State가 아닌 Event로 감지하도록 변경

## PR 포인트
### 호출 시점에 대한 고민
![image](https://github.com/user-attachments/assets/8f95c553-3aee-4170-ad86-0db0e32f77ab)

[공식문서](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-lifecycle.html#ios)에 iOS 생명주기 기준으로 어떤 Lifecycle.Event/State가 나오는지 명시되어 있더군요!
말씀해주신대로 예측 뒤로가기가 실행되면 iOS 기준으로 viewDidDisapper가 실행될 것이고 STARTED -> CREATED가 실행되고 있습니다.

구현은 ON_START 부분이 저희가 원하는 초기화 시점이 될 것 같아 ON_START마다 API를 호출하도록 했습니다.
`LifecycleEventObserver`를 통해서 Event를 감지하고 화면이 사라질 때 onDispose로 observer를 해제하게 했습니다. 해당 부분은 많이 사용될 것 같은데 괜찮다면 유틸이나 컴포넌트로 옮기는건 어떤가요?