### PR TITLE
[Refactor] 시간 관련 엔티티 자료형 변경 (Long -> String)

### DIFF
--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
@@ -65,10 +65,10 @@ internal fun CaramelNavHost(
             )
             settingScreen(
                 navigateToHome = { popBackStack() },
-                navigateToEditBirthday = { birthdayMillisecond ->
+                navigateToEditBirthday = { birthday ->
                     navigateToEditProfile(
                         editType = ProfileEditType.BIRTHDAY,
-                        birthdayMillisecond = birthdayMillisecond
+                        birthday = birthday
                     )
                 },
                 navigateToEditNickName = { nickname ->
@@ -84,10 +84,10 @@ internal fun CaramelNavHost(
                         }
                     }
                 },
-                navigateToEditCountDown = { startDateMillisecond ->
+                navigateToEditCountDown = { startDate ->
                     navigateToEditProfile(
                         editType = ProfileEditType.START_DATE,
-                        startDateMillisecond = startDateMillisecond
+                        startDate = startDate
                     )
                 }
             )

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/AuthMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/AuthMapper.kt
@@ -5,14 +5,13 @@ import com.whatever.caramel.core.domain.vo.auth.UserAuth
 import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.core.remote.dto.auth.ServiceTokenDto
 import com.whatever.caramel.core.remote.dto.auth.response.SignInResponse
-import com.whatever.caramel.core.util.DateParser.toMillisecond
 
 fun SignInResponse.toUserAuth(): UserAuth {
     return UserAuth(
         coupleId = this.coupleId,
         nickname = this.nickname,
         userStatus = UserStatus.valueOf(this.userStatus.name),
-        birthDayMillisecond = this.birthDay?.toMillisecond(),
+        birthday = this.birthDay ?: "",
         authToken = serviceToken.toAuthToken()
     )
 }

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/CoupleMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/CoupleMapper.kt
@@ -2,8 +2,6 @@ package com.whatever.caramel.core.data.mapper
 
 import com.whatever.caramel.core.domain.entity.Couple
 import com.whatever.caramel.core.domain.entity.User
-import com.whatever.caramel.core.domain.exception.CaramelException
-import com.whatever.caramel.core.domain.exception.code.AppErrorCode
 import com.whatever.caramel.core.domain.vo.couple.CoupleInvitationCode
 import com.whatever.caramel.core.domain.vo.couple.CoupleRelationship
 import com.whatever.caramel.core.domain.vo.couple.CoupleStatus
@@ -13,19 +11,17 @@ import com.whatever.caramel.core.remote.dto.couple.CoupleUserInfoDto
 import com.whatever.caramel.core.remote.dto.couple.response.CoupleBasicResponse
 import com.whatever.caramel.core.remote.dto.couple.response.CoupleDetailResponse
 import com.whatever.caramel.core.remote.dto.couple.response.CoupleInvitationCodeResponse
-import com.whatever.caramel.core.util.DateParser.toMillisecond
-import kotlinx.datetime.Instant
 
 fun CoupleInvitationCodeResponse.toCoupleInvitationCode() = CoupleInvitationCode(
     invitationCode = this.invitationCode,
-    expirationMillisecond = Instant.parse(expirationDateTime).toEpochMilliseconds()
+    expirationDateTime = expirationDateTime
 )
 
 fun CoupleDetailResponse.toCoupleRelationship(): CoupleRelationship =
     CoupleRelationship(
         info = Couple(
             id = this.coupleId,
-            startDateMillis = this.startDate?.toMillisecond() ?: 0L,
+            startDate = this.startDate?.replace("-", ".") ?: "",
             sharedMessage = this.sharedMessage ?: "",
             status = CoupleStatus.valueOf(this.status.name)
         ),
@@ -38,7 +34,7 @@ fun CoupleUserInfoDto.toUser(): User =
         id = this.id,
         userProfile = UserProfile(
             nickName = this.nickname,
-            birthdayMillisecond = this.birthDate.toMillisecond() ?: 0L,
+            birthday = this.birthDate.replace("-", "."),
             gender = Gender.valueOf(this.gender.name)
         )
     )
@@ -46,15 +42,7 @@ fun CoupleUserInfoDto.toUser(): User =
 fun CoupleBasicResponse.toCouple(): Couple =
     Couple(
         id = this.coupleId,
-        startDateMillis = this.startDate?.toMillisecond() ?: throw CaramelException(
-            code = AppErrorCode.INVALID_PARAMS,
-            message = "알 수 없는 오류입니다.",
-            debugMessage = "날짜 형식 변환에 실패했습니다."
-        ),
-        sharedMessage = this.sharedMessage ?: throw CaramelException(
-            code = AppErrorCode.INVALID_PARAMS,
-            message = "알 수 없는 오류입니다.",
-            debugMessage = "공유 메시지 형식 변환에 실패했습니다."
-        ),
+        startDate = this.startDate?.replace("-", ".") ?: "",
+        sharedMessage = this.sharedMessage ?: "",
         status = CoupleStatus.valueOf(this.status.name)
     )

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/UserMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/UserMapper.kt
@@ -4,10 +4,9 @@ import com.whatever.caramel.core.domain.entity.User
 import com.whatever.caramel.core.domain.vo.user.Gender
 import com.whatever.caramel.core.domain.vo.user.UserProfile
 import com.whatever.caramel.core.domain.vo.user.UserStatus
+import com.whatever.caramel.core.remote.dto.user.UserStatusDto
 import com.whatever.caramel.core.remote.dto.user.response.EditUserProfileResponse
 import com.whatever.caramel.core.remote.dto.user.response.UserProfileResponse
-import com.whatever.caramel.core.remote.dto.user.UserStatusDto
-import com.whatever.caramel.core.util.DateParser.toMillisecond
 
 fun String.toUserStatus() : UserStatus {
     return UserStatus.entries.find { it.name == this } ?: UserStatus.NONE
@@ -25,7 +24,7 @@ fun UserProfileResponse.toUser() = User(
     userProfile = UserProfile(
         nickName = this.nickname,
         gender = Gender.IDLE,
-        birthdayMillisecond = 0L
+        birthday = ""
     )
 )
 
@@ -35,6 +34,6 @@ fun EditUserProfileResponse.toUser() = User(
     userProfile = UserProfile(
         nickName = this.nickname,
         gender = Gender.IDLE,
-        birthdayMillisecond = this.birthday.toMillisecond() ?: 0L
+        birthday = this.birthday.replace("-", ".")
     )
 )

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Couple.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Couple.kt
@@ -4,7 +4,7 @@ import com.whatever.caramel.core.domain.vo.couple.CoupleStatus
 
 data class Couple(
     val id: Long,
-    val startDateMillis: Long,
+    val startDate: String,
     val sharedMessage: String,
     val status: CoupleStatus,
 )

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/vo/auth/UserAuth.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/vo/auth/UserAuth.kt
@@ -6,6 +6,6 @@ data class UserAuth(
     val coupleId : Long? = null,
     val userStatus: UserStatus,
     val nickname : String? = null,
-    val birthDayMillisecond : Long? = null,
+    val birthday : String? = null,
     val authToken : AuthToken,
 )

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/vo/couple/CoupleInvitationCode.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/vo/couple/CoupleInvitationCode.kt
@@ -2,5 +2,5 @@ package com.whatever.caramel.core.domain.vo.couple
 
 data class CoupleInvitationCode(
     val invitationCode: String,
-    val expirationMillisecond: Long
+    val expirationDateTime: String
 )

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/vo/user/UserProfile.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/vo/user/UserProfile.kt
@@ -3,5 +3,5 @@ package com.whatever.caramel.core.domain.vo.user
 data class UserProfile(
     val nickName : String,
     val gender : Gender,
-    val birthdayMillisecond : Long
+    val birthday : String
 )

--- a/core/testing/src/commonMain/kotlin/com/whatever/caramel/core/testing/constants/TestUserInfo.kt
+++ b/core/testing/src/commonMain/kotlin/com/whatever/caramel/core/testing/constants/TestUserInfo.kt
@@ -9,7 +9,7 @@ object TestUserInfo {
     const val INVALID_LENGTH_NICKNAME = "testUserUser"
     const val INVALID_PATTERN_NICKNAME = "test_use"
 
-    const val TEST_BIRTH_DAY_MILLISECOND = 879724800000L
+    const val TEST_BIRTH_DAY = "2025.04.03"
 
     val TEST_USER_GENDER = Gender.MALE
 }

--- a/core/testing/src/commonMain/kotlin/com/whatever/caramel/core/testing/factory/AuthTestFactory.kt
+++ b/core/testing/src/commonMain/kotlin/com/whatever/caramel/core/testing/factory/AuthTestFactory.kt
@@ -22,7 +22,7 @@ object AuthTestFactory {
         coupleId = null,
         userStatus = UserStatus.SINGLE,
         nickname = TestUserInfo.TEST_USER_NICKNAME,
-        birthDayMillisecond = TestUserInfo.TEST_BIRTH_DAY_MILLISECOND,
+        birthday = TestUserInfo.TEST_BIRTH_DAY,
         authToken = createValidToken()
     )
 
@@ -30,7 +30,7 @@ object AuthTestFactory {
         coupleId = null,
         userStatus = UserStatus.NEW,
         nickname = null,
-        birthDayMillisecond = null,
+        birthday = null,
         authToken = createValidToken()
     )
 
@@ -38,7 +38,7 @@ object AuthTestFactory {
         coupleId = TestCoupleInfo.TEST_COUPLE_ID,
         userStatus = UserStatus.COUPLED,
         nickname = TestUserInfo.TEST_USER_NICKNAME,
-        birthDayMillisecond = TestUserInfo.TEST_BIRTH_DAY_MILLISECOND,
+        birthday = TestUserInfo.TEST_BIRTH_DAY,
         authToken = createValidToken()
     )
 }

--- a/core/testing/src/commonMain/kotlin/com/whatever/caramel/core/testing/factory/UserTestFactory.kt
+++ b/core/testing/src/commonMain/kotlin/com/whatever/caramel/core/testing/factory/UserTestFactory.kt
@@ -12,7 +12,7 @@ object UserTestFactory {
         userStatus = UserStatus.SINGLE,
         userProfile = UserProfile(
             nickName = TestUserInfo.TEST_USER_NICKNAME,
-            birthdayMillisecond = TestUserInfo.TEST_BIRTH_DAY_MILLISECOND,
+            birthday = TestUserInfo.TEST_BIRTH_DAY,
             gender = TestUserInfo.TEST_USER_GENDER,
         ),
         userMetaData = UserMetaData(

--- a/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/picker/model/DateUiSate.kt
+++ b/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/picker/model/DateUiSate.kt
@@ -1,6 +1,5 @@
 package com.whatever.caramel.core.ui.picker.model
 
-import com.whatever.caramel.core.util.DateFormatter.toLocalDateTime
 import com.whatever.caramel.core.util.DateUtil
 
 // @ham2174 FIXME : DateMonthPicker 또는 DatePicker 의 상태 변경시 DateUiState / DateMonthUiState 로 분리
@@ -20,13 +19,14 @@ data class DateUiState(
             )
         }
 
-        fun get(millisecond: Long) : DateUiState {
-            val localDateTime = millisecond.toLocalDateTime()
-            return DateUiState(
-                year = localDateTime.year,
-                month = localDateTime.monthNumber,
-                day = localDateTime.dayOfMonth
-            )
+        fun get(dateString: String): DateUiState {
+            return runCatching {
+                val dateNumber = dateString.replace(Regex("[^0-9]"), "")
+                val year = dateNumber.substring(0, 4).toInt()
+                val month = dateNumber.substring(4, 6).toInt()
+                val day = dateNumber.substring(6, 8).toInt()
+                DateUiState(year, month, day)
+            }.getOrNull() ?: currentDate()
         }
     }
 }

--- a/core/util/src/commonTest/kotlin/com/whatever/caramel/core/util/DateUtilTest.kt
+++ b/core/util/src/commonTest/kotlin/com/whatever/caramel/core/util/DateUtilTest.kt
@@ -100,7 +100,7 @@ class DateUtilTest {
 
         assertEquals(
             expected = VALID_MILLISECOND,
-            actual = "2025-04-12".toMillisecond()
+            actual = "1900-04-12".toMillisecond()
         )
     }
 

--- a/feature/profile/edit/src/commonMain/kotlin/com/whatever/caramel/feature/profile/edit/ProfileEditViewModel.kt
+++ b/feature/profile/edit/src/commonMain/kotlin/com/whatever/caramel/feature/profile/edit/ProfileEditViewModel.kt
@@ -26,15 +26,15 @@ class ProfileEditViewModel(
         return ProfileEditState(
             editUiType = ProfileEditType.valueOf(arguments.editType),
             nickName = arguments.nickname,
-            birthDay = if (arguments.birthdayMillisecond == 0L) {
+            birthDay = if (arguments.birthday.isEmpty()) {
                 DateUiState.currentDate()
             } else {
-                DateUiState.get(arguments.birthdayMillisecond)
+                DateUiState.get(arguments.birthday)
             },
-            startDate = if (arguments.startDateMillisecond == 0L) {
+            startDate = if (arguments.startDate.isEmpty()) {
                 DateUiState.currentDate()
             } else {
-                DateUiState.get(arguments.startDateMillisecond)
+                DateUiState.get(arguments.startDate)
             }
         )
     }

--- a/feature/profile/edit/src/commonMain/kotlin/com/whatever/caramel/feature/profile/edit/navigation/ProfileEditNavigation.kt
+++ b/feature/profile/edit/src/commonMain/kotlin/com/whatever/caramel/feature/profile/edit/navigation/ProfileEditNavigation.kt
@@ -4,7 +4,6 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import androidx.navigation.toRoute
 import com.whatever.caramel.feature.profile.edit.ProfileEditRoute
 import com.whatever.caramel.feature.profile.edit.mvi.ProfileEditType
 import kotlinx.serialization.Serializable
@@ -13,23 +12,23 @@ import kotlinx.serialization.Serializable
 data class ProfileEditRoute(
     val editType: String,
     val nickname: String,
-    val birthdayMillisecond: Long,
-    val startDateMillisecond: Long
+    val birthday: String,
+    val startDate: String
 )
 
 fun NavHostController.navigateToEditProfile(
     editType: ProfileEditType,
     nickname: String = "",
-    birthdayMillisecond: Long = 0L,
-    startDateMillisecond: Long = 0L,
+    birthday: String = "",
+    startDate: String = "",
     navOptions: NavOptions? = null
 ) {
     navigate(
         route = ProfileEditRoute(
             editType = editType.name,
             nickname = nickname,
-            birthdayMillisecond = birthdayMillisecond,
-            startDateMillisecond = startDateMillisecond
+            birthday = birthday,
+            startDate = startDate
         ),
         navOptions = navOptions
     )

--- a/feature/setting/src/androidMain/kotlin/com/whatever/caramel/feature/setting/component/data/SettingScreenPreviewData.kt
+++ b/feature/setting/src/androidMain/kotlin/com/whatever/caramel/feature/setting/component/data/SettingScreenPreviewData.kt
@@ -17,17 +17,17 @@ internal class SettingScreenPreviewDataProvider :
             state = SettingState(
                 isLoading = false,
                 isShowEditProfileBottomSheet = true,
-                startDateTimeMillisecond = 1743897600000L,
+                startDate = "2025.04.03",
                 myInfo = CoupleUser(
                     id = 123L,
                     nickname = "닉네임",
-                    birthDayTimeMillisecond = 1743897600000L,
+                    birthday = "2025.04.03",
                     gender = Gender.MALE
                 ),
                 partnerInfo = CoupleUser(
                     id = 1234L,
                     nickname = "상대 닉네임",
-                    birthDayTimeMillisecond = 1743897600000L,
+                    birthday = "2025.04.03",
                     gender = Gender.FEMALE
                 )
             )
@@ -35,17 +35,17 @@ internal class SettingScreenPreviewDataProvider :
         SettingScreenPreviewData(
             state = SettingState(
                 isLoading = false,
-                startDateTimeMillisecond = 1743897600000L,
+                startDate = "2025.04.03",
                 myInfo = CoupleUser(
                     id = 123L,
                     nickname = "닉네임",
-                    birthDayTimeMillisecond = 1743897600000L,
+                    birthday = "2025.04.03",
                     gender = Gender.MALE
                 ),
                 partnerInfo = CoupleUser(
                     id = 1234L,
                     nickname = "상대 닉네임",
-                    birthDayTimeMillisecond = 1743897600000L,
+                    birthday = "2025.04.03",
                     gender = Gender.FEMALE
                 )
             )

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingRoute.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingRoute.kt
@@ -15,8 +15,8 @@ internal fun SettingRoute(
     viewModel: SettingViewModel = koinViewModel(),
     navigateToHome: () -> Unit,
     navigateToLogin: () -> Unit,
-    navigateToEditCountDown: (Long) -> Unit,
-    navigateToEditBirthday: (Long) -> Unit,
+    navigateToEditCountDown: (String) -> Unit,
+    navigateToEditBirthday: (String) -> Unit,
     navigateToEditNickName: (String) -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -34,9 +34,9 @@ internal fun SettingRoute(
                 SettingSideEffect.NavigateToServiceTermNotion -> TODO()
                 SettingSideEffect.NavigateLogin -> navigateToLogin()
                 is SettingSideEffect.NavigateToHome -> navigateToHome()
-                is SettingSideEffect.NavigateToEditCountDown -> navigateToEditCountDown(sideEffect.startDateMillisecond)
+                is SettingSideEffect.NavigateToEditCountDown -> navigateToEditCountDown(sideEffect.startDate)
                 is SettingSideEffect.NavigateToEditNickname -> navigateToEditNickName(sideEffect.nickname)
-                is SettingSideEffect.NavigateToEditBirthDay -> navigateToEditBirthday(sideEffect.birthdayMillisecond)
+                is SettingSideEffect.NavigateToEditBirthday -> navigateToEditBirthday(sideEffect.birthday)
             }
         }
     }

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingScreen.kt
@@ -101,7 +101,9 @@ internal fun SettingScreen(
                     )
             ) {
                 Text(
-                    text = state.startDate,
+                    text = state.startDate.ifEmpty {
+                        "언제부터 사귀기 시작했나요?"
+                    },
                     style = CaramelTheme.typography.body2.regular,
                     color = CaramelTheme.color.text.secondary
                 )
@@ -123,7 +125,7 @@ internal fun SettingScreen(
                 SettingUserProfile(
                     gender = state.myInfo.gender,
                     nickname = state.myInfo.nickname,
-                    birthDay = state.myInfo.birthDate,
+                    birthDay = state.myInfo.birthday,
                     isEditable = true,
                     onClickEditProfile = { onIntent(SettingIntent.ToggleEditProfile) }
                 )
@@ -131,7 +133,7 @@ internal fun SettingScreen(
                 SettingUserProfile(
                     gender = state.partnerInfo.gender,
                     nickname = state.partnerInfo.nickname,
-                    birthDay = state.partnerInfo.birthDate,
+                    birthDay = state.partnerInfo.birthday,
                     isEditable = false
                 )
             }

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingViewModel.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingViewModel.kt
@@ -29,11 +29,11 @@ class SettingViewModel(
             SettingIntent.ClickPrivacyPolicyButton -> postSideEffect(SettingSideEffect.NavigateToPersonalInfoTermNotion)
             SettingIntent.ClickTermsOfServiceButtons -> postSideEffect(SettingSideEffect.NavigateToServiceTermNotion)
             SettingIntent.ClickLogoutConfirmButton -> logout()
-            SettingIntent.ClickEditBirthDayButton -> naviateEditBirthday()
+            SettingIntent.ClickEditBirthDayButton -> navigateEditBirthday()
             SettingIntent.ClickEditNicknameButton -> navigateEditNickname()
             SettingIntent.ClickEditCountDownButton -> postSideEffect(
                 SettingSideEffect.NavigateToEditCountDown(
-                    startDateMillisecond = currentState.startDateTimeMillisecond
+                    startDate = currentState.startDate
                 )
             )
             SettingIntent.ToggleUserCancelledButton -> toggleUserCancelledButton()
@@ -58,7 +58,7 @@ class SettingViewModel(
             reduce {
                 copy(
                     isLoading = false,
-                    startDateTimeMillisecond = couple.info.startDateMillis,
+                    startDate = couple.info.startDate,
                     myInfo = CoupleUser.toCoupleInfo(couple.myInfo),
                     partnerInfo = CoupleUser.toCoupleInfo(couple.partnerInfo),
                 )
@@ -99,11 +99,11 @@ class SettingViewModel(
         )
     }
 
-    private fun naviateEditBirthday(){
+    private fun navigateEditBirthday(){
         toggleEditProfileBottomSheet()
         postSideEffect(
-            SettingSideEffect.NavigateToEditBirthDay(
-                birthdayMillisecond = currentState.myInfo.birthDayTimeMillisecond
+            SettingSideEffect.NavigateToEditBirthday(
+                birthday = currentState.myInfo.birthday
             )
         )
     }

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/mvi/SettingSideEffect.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/mvi/SettingSideEffect.kt
@@ -8,7 +8,7 @@ sealed interface SettingSideEffect : UiSideEffect {
 
     data class NavigateToEditNickname(val nickname: String) : SettingSideEffect
 
-    data class NavigateToEditBirthDay(val birthdayMillisecond: Long) : SettingSideEffect
+    data class NavigateToEditBirthday(val birthday: String) : SettingSideEffect
 
     data object NavigateToServiceTermNotion : SettingSideEffect
 
@@ -16,5 +16,5 @@ sealed interface SettingSideEffect : UiSideEffect {
 
     data object NavigateLogin : SettingSideEffect
 
-    data class NavigateToEditCountDown(val startDateMillisecond: Long) : SettingSideEffect
+    data class NavigateToEditCountDown(val startDate: String) : SettingSideEffect
 }

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/mvi/SettingState.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/mvi/SettingState.kt
@@ -7,38 +7,24 @@ import com.whatever.caramel.core.viewmodel.UiState
 
 data class SettingState(
     val isLoading: Boolean = false,
-    val startDateTimeMillisecond: Long = 0L,
+    val startDate: String = "",
     val myInfo: CoupleUser = CoupleUser(),
     val partnerInfo: CoupleUser = CoupleUser(),
     val isShowEditProfileBottomSheet: Boolean = false,
     val isShowLogoutDialog: Boolean = false,
     val isShowUserCancelledDialog: Boolean = false
-) : UiState {
-    val startDate: String
-        get() = if (startDateTimeMillisecond == 0L) {
-            "언제부터 사귀기 시작했나요?"
-        } else {
-            startDateTimeMillisecond.toFormattedDate(separator = ".") ?: ""
-        }
-}
+) : UiState
 
 data class CoupleUser(
     val id: Long = 0L,
     val nickname: String = "",
-    val birthDayTimeMillisecond: Long = 0L,
+    val birthday: String = "",
     val gender: Gender = Gender.IDLE
 ) {
-    val birthDate: String
-        get() = if(birthDayTimeMillisecond == 0L) {
-            ""
-        } else {
-            birthDayTimeMillisecond.toFormattedDate(separator = ".") ?: ""
-        }
-
     companion object {
         fun toCoupleInfo(user: User) = CoupleUser(
             id = user.requireId,
-            birthDayTimeMillisecond = user.requireProfile.birthdayMillisecond,
+            birthday = user.requireProfile.birthday,
             nickname = user.requireProfile.nickName,
             gender = user.requireProfile.gender
         )

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/navigation/SettingNavigation.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/navigation/SettingNavigation.kt
@@ -20,8 +20,8 @@ fun NavController.navigateToSetting(navOptions: NavOptions? = null) {
 fun NavGraphBuilder.settingScreen(
     navigateToHome: () -> Unit,
     navigateToLogin: () -> Unit,
-    navigateToEditCountDown: (Long) -> Unit,
-    navigateToEditBirthday: (Long) -> Unit,
+    navigateToEditCountDown: (String) -> Unit,
+    navigateToEditBirthday: (String) -> Unit,
     navigateToEditNickName: (String) -> Unit
 ) {
     composable<SettingRoute> {


### PR DESCRIPTION
## 관련 이슈
- #120 

## 작업한 내용
- 밀리초로 작성된 날짜들을 문자열로 변경
  - User(birthday)
  - Couple(expirationDateTime, startDate)

## PR 포인트
도메인이 바뀌니 전체적으로 다 바뀌네요.. 커밋 단위가 애매해서 전체 파일 변화로 보시는게 편할 것 같습니다.
### 1. date에 대한 seperator 변경
현재 서버에서는 YYYY-MM-DD로 내려오고 있고 UI는 YYYY.MM.DD를 사용하고 있습니다.
백앤드분들께 여쭤보니 공수가 많이 들지는 않지만 DB에 LocalDate를 저장하고 있다하여 클라이언트에서 Mapper를 통해 변경하도록 했습니다.

### 2. DateUiState의 get 변경
기존에 밀리초를 기준으로 LocalDate를 가져오는 로직이었습니다.
하지만 String으로 변경함으로써 파라미터로 String을 받아 파싱하도록 변경되었습니다.
만약 올바른 날짜 형식이 아니라면 현재시간을 기준으로 파싱됩니다.

UI에서 잘못된 날짜가 파싱될 경우 오류를 내보낼건지, 현재날짜라도(초기 설정과 동일) 보여지게 할건지 이야기 해야할 것 같아요!