### PR TITLE
[Fix] CaramelViewModel DI 플랫별로 분기

### DIFF
--- a/app/src/androidMain/kotlin/com/whatever/caramel/GlobalApplication.kt
+++ b/app/src/androidMain/kotlin/com/whatever/caramel/GlobalApplication.kt
@@ -10,6 +10,7 @@ import io.github.aakira.napier.Napier
 import org.koin.android.ext.koin.androidContext
 
 class GlobalApplication : Application() {
+
     override fun onCreate() {
         super.onCreate()
 

--- a/app/src/androidMain/kotlin/com/whatever/caramel/di/Module.android.kt
+++ b/app/src/androidMain/kotlin/com/whatever/caramel/di/Module.android.kt
@@ -1,0 +1,11 @@
+package com.whatever.caramel.di
+
+import com.whatever.caramel.app.CaramelViewModel
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+
+actual val appViewModelModule: Module
+    get() = module {
+        viewModelOf(::CaramelViewModel)
+    }

--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelComposeApp.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelComposeApp.kt
@@ -24,11 +24,12 @@ import com.whatever.caramel.feature.main.navigation.navigateToMain
 import com.whatever.caramel.feature.profile.create.navigation.navigateToCreateProfile
 import com.whatever.caramel.mvi.AppIntent
 import com.whatever.caramel.mvi.AppSideEffect
+import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun CaramelComposeApp(
     navHostController: NavHostController,
-    viewModel: CaramelViewModel
+    viewModel: CaramelViewModel = koinViewModel()
 ) {
     CaramelTheme {
         val snackBarHostState = remember { SnackbarHostState() }
@@ -78,6 +79,7 @@ fun CaramelComposeApp(
                                     }
                                 }
                             }
+
                             is AppSideEffect.NavigateToConnectingCoupleScreen -> {
                                 navHostController.navigateToConnectingCouple {
                                     popUpTo(navHostController.graph.id) {
@@ -85,12 +87,15 @@ fun CaramelComposeApp(
                                     }
                                 }
                             }
+
                             is AppSideEffect.NavigateToCreateProfile -> {
                                 navHostController.navigateToCreateProfile()
                             }
+
                             is AppSideEffect.NavigateToLogin -> {
                                 navHostController.navigateToLogin()
                             }
+
                             is AppSideEffect.NavigateToMain -> {
                                 navHostController.navigateToMain()
                             }

--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
@@ -38,11 +38,11 @@ internal fun CaramelNavHost(
     ) {
         with(navHostController) {
             splashScreen(
-                navigateToStartDestination = { onIntent(AppIntent.NavigateToStartDestination)},
+                navigateToStartDestination = { onIntent(AppIntent.NavigateToStartDestination) },
                 navigateToLogin = { navigateToLogin() },
             )
             loginScreen(
-                navigateToStartDestination = { onIntent(AppIntent.NavigateToStartDestination)},
+                navigateToStartDestination = { onIntent(AppIntent.NavigateToStartDestination) },
             )
             createProfileScreen(
                 navigateToLogin = { navigateToLogin() },

--- a/app/src/commonMain/kotlin/com/whatever/caramel/di/Module.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/di/Module.kt
@@ -1,10 +1,5 @@
 package com.whatever.caramel.di
 
-import com.whatever.caramel.app.CaramelViewModel
-import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.module.Module
 
-import org.koin.dsl.module
-
-val appModule = module {
-    viewModelOf(::CaramelViewModel)
-}
+expect val appViewModelModule: Module

--- a/app/src/commonMain/kotlin/com/whatever/caramel/di/initKoin.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/di/initKoin.kt
@@ -34,7 +34,8 @@ fun initKoin(config: KoinAppDeclaration? = null) {
         config?.invoke(this)
         modules(
             /* === App Layer === */
-            appModule,
+            appViewModelModule,
+
 
             /* ==== Data Layer ==== */
             repositoryModule,

--- a/app/src/iosMain/kotlin/com/whatever/caramel/MainViewController.kt
+++ b/app/src/iosMain/kotlin/com/whatever/caramel/MainViewController.kt
@@ -5,11 +5,9 @@ package com.whatever.caramel
 import androidx.compose.ui.window.ComposeUIViewController
 import androidx.navigation.compose.rememberNavController
 import com.whatever.caramel.app.CaramelComposeApp
-import com.whatever.caramel.app.CaramelViewModel
 import com.whatever.caramel.di.initKoin
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
-import org.koin.compose.viewmodel.koinViewModel
 import kotlin.experimental.ExperimentalNativeApi
 
 @OptIn(ExperimentalNativeApi::class)
@@ -21,10 +19,8 @@ fun MainViewController() = ComposeUIViewController(
     }
 
     val navHostController = rememberNavController()
-    val viewModel: CaramelViewModel = koinViewModel()
 
     CaramelComposeApp(
         navHostController = navHostController,
-        viewModel = viewModel
     )
 }

--- a/app/src/iosMain/kotlin/com/whatever/caramel/di/Module.ios.kt
+++ b/app/src/iosMain/kotlin/com/whatever/caramel/di/Module.ios.kt
@@ -1,0 +1,23 @@
+package com.whatever.caramel.di
+
+
+import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.app.CaramelViewModel
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+
+actual val appViewModelModule: Module
+    get() = module {
+        viewModel {
+            CaramelViewModel(
+                getUserStatusUseCase = get(),
+                connectCoupleUseCase = get(),
+                savedStateHandle = SavedStateHandle()
+                /*
+                 @ham2174 FIXME : SavedStateHandle Ios에서 사용 불가능.
+                 koin-compose-viewmodel 버전이 업데이트 되기 전까지 CaramelViewModel 의 SavedStateHandle 사용 불가
+                */
+            )
+        }
+    }


### PR DESCRIPTION
## 작업한 내용
- iOS에서 뷰모델 내부 SavedStateHandle으로 인한 런타임 오류 해결

## PR 포인트
- Android / iOS 플랫폼별 DI 분기처리