### PR TITLE
[Fix] 캘린더 일정조회 API URL 변경

### DIFF
--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/datasource/RemoteCalendarDataSourceImpl.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/datasource/RemoteCalendarDataSourceImpl.kt
@@ -28,7 +28,7 @@ internal class RemoteCalendarDataSourceImpl(
         endDate: String,
         userTimeZone: String?
     ): CalendarDetailResponse {
-        return authClient.get("$CALENDAR_BASE_URL/schedules") {
+        return authClient.get(CALENDAR_BASE_URL) {
             parameter("startDate", startDate)
             parameter("endDate", endDate)
             parameter("userTimeZone", userTimeZone)


### PR DESCRIPTION
### 작업 내용
- 캘린더 일정조회 API URL 변경 (/v1/scalendar/schedules -> /v1/scalendar)