### PR TITLE
[QA] 컨텐츠 제목/설명 생성 및 수정시에 하나라도 존재하면 허용되도록 수정

### DIFF
--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/vo/calendar/ScheduleEditParameter.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/vo/calendar/ScheduleEditParameter.kt
@@ -2,8 +2,8 @@ package com.whatever.caramel.core.domain.vo.calendar
 
 data class ScheduleEditParameter(
     val selectedDate: String,
-    val title: String,
-    val description: String,
+    val title: String?,
+    val description: String?,
     val isCompleted: Boolean,
     val startDateTime: String,
     val startTimeZone: String,

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/vo/calendar/ScheduleParameter.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/vo/calendar/ScheduleParameter.kt
@@ -1,8 +1,8 @@
 package com.whatever.caramel.core.domain.vo.calendar
 
 data class ScheduleParameter(
-    val title: String,
-    val description: String,
+    val title: String?,
+    val description: String?,
     val isCompleted: Boolean,
     val startDateTime: String,
     val startTimeZone: String,

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/vo/memo/MemoParameter.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/vo/memo/MemoParameter.kt
@@ -1,8 +1,8 @@
 package com.whatever.caramel.core.domain.vo.memo
 
 data class MemoParameter(
-    val title: String,
-    val description: String,
+    val title: String?,
+    val description: String?,
     val isCompleted: Boolean,
     val tags: List<Long>?
 ) 

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/dto/calendar/request/CreateScheduleRequest.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/dto/calendar/request/CreateScheduleRequest.kt
@@ -6,9 +6,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CreateScheduleRequest(
     @SerialName("title")
-    val title: String,
+    val title: String?,
     @SerialName("description")
-    val description: String,
+    val description: String?,
     @SerialName("isCompleted")
     val isCompleted: Boolean,
     @SerialName("startDateTime")

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/dto/calendar/request/UpdateScheduleRequest.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/dto/calendar/request/UpdateScheduleRequest.kt
@@ -5,8 +5,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class UpdateScheduleRequest(
     val selectedDate: String,
-    val title: String,
-    val description: String,
+    val title: String?,
+    val description: String?,
     val isCompleted: Boolean,
     val startDateTime: String,
     val startTimeZone: String,

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/dto/memo/request/CreateMemoRequest.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/dto/memo/request/CreateMemoRequest.kt
@@ -7,9 +7,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CreateMemoRequest(
     @SerialName("title")
-    val title: String,
+    val title: String?,
     @SerialName("description")
-    val description: String,
+    val description: String?,
     @SerialName("isCompleted")
     val isCompleted: Boolean,
     @SerialName("tags")

--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
@@ -204,8 +204,8 @@ class ContentCreateViewModel(
             val parameter = when (state.createMode) {
                 CreateMode.MEMO -> ContentParameterType.Memo(
                     MemoParameter(
-                        title = state.title,
-                        description = state.content,
+                        title = state.title.ifBlank { null },
+                        description = state.content.ifBlank { null },
                         isCompleted = false,
                         tags = state.selectedTags.map { it.id }.toList()
                     )
@@ -213,8 +213,8 @@ class ContentCreateViewModel(
 
                 CreateMode.CALENDAR -> ContentParameterType.Calendar(
                     ScheduleParameter(
-                        title = state.title,
-                        description = state.content,
+                        title = state.title.ifBlank { null },
+                        description = state.content.ifBlank { null },
                         isCompleted = false,
                         startDateTime = state.dateTime.toInstant(TimeZone.currentSystemDefault())
                             .toString(),

--- a/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditViewModel.kt
+++ b/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditViewModel.kt
@@ -121,8 +121,8 @@ class ContentEditViewModel(
                     updateMemoUseCase(
                         memoId = state.contentId,
                         parameter = MemoEditParameter(
-                            title = state.title,
-                            description = state.content,
+                            title = state.title.ifBlank { null },
+                            description = state.content.ifBlank { null },
                             isCompleted = null,
                             tagIds = state.selectedTags.map { it.id }.toList(),
                             dateTimeInfo = null
@@ -136,9 +136,9 @@ class ContentEditViewModel(
                     updateScheduleUseCase(
                         scheduleId = state.contentId,
                         parameter = ScheduleEditParameter(
-                            selectedDate = "",
-                            title = state.title,
-                            description = state.content,
+                            selectedDate = state.dateTime.date.toString(),
+                            title = state.title.ifBlank { null },
+                            description = state.content.ifBlank { null },
                             isCompleted = false,
                             startDateTime = currentInstant.toString(),
                             startTimeZone = TimeZone.currentSystemDefault().id,


### PR DESCRIPTION
## 관련 이슈
- https://www.notion.so/given-dragon/205870f222b980fd8aebe57e3c697b33?source=copy_link

## 작업한 내용
- 컨텐츠 제목/설명 생성 및 수정시에 하나라도 존재하면 허용되도록 수정
