### PR TITLE
[QA] 커플 연결 후 커플 ID를 저장하도록 변경

### DIFF
--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/couple/ConnectCoupleUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/couple/ConnectCoupleUseCase.kt
@@ -13,7 +13,7 @@ class ConnectCoupleUseCase(
     ) {
         val coupleRelationship = coupleRepository.connectCouple(invitationCode = invitationCode)
         val myInfo = coupleRelationship.myInfo
-
+        coupleRepository.setCoupleId(coupleRelationship.info.id)
         userRepository.setUserStatus(myInfo.userStatus)
     }
 


### PR DESCRIPTION
## 작업한 내용
- 커플 연결 API 이후 커플 ID를 DataStore에 저장하도록 변경