### PR TITLE
[QA] 홈 - 밸런스 게임 카드 애니메이션이 동작 오류 수정

### DIFF
--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeScreen.kt
@@ -112,7 +112,6 @@ internal fun HomeScreen(
                 )
 
                 Quiz(
-                    rotated = state.isBalanceGameCardRotated,
                     question = state.balanceGameState.question,
                     options = state.balanceGameState.options,
                     balanceGameAnswerState = state.balanceGameAnswerState,
@@ -124,7 +123,6 @@ internal fun HomeScreen(
                     myChoiceOption = state.myChoiceOption,
                     partnerChoiceOption = state.partnerChoiceOption,
                     onOptionClick = { option -> onIntent(HomeIntent.ClickBalanceGameOptionButton(option = option)) },
-                    onClickResult = { onIntent(HomeIntent.ClickBalanceGameResultButton) },
                     onChangeCardState = { onIntent(HomeIntent.ChangeBalanceGameCardState) }
                 )
 

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
@@ -27,12 +27,6 @@ class HomeViewModel(
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<HomeState, HomeSideEffect, HomeIntent>(savedStateHandle) {
 
-    init {
-        launch {
-
-        }
-    }
-
     override fun createInitialState(savedStateHandle: SavedStateHandle): HomeState {
         return HomeState()
     }
@@ -49,19 +43,14 @@ class HomeViewModel(
                     )
                 )
             }
-
             is HomeIntent.CreateTodoContent -> postSideEffect(HomeSideEffect.NavigateToCreateContent)
             is HomeIntent.SaveShareMessage -> saveShareMessage(newShareMessage = intent.newShareMessage)
             is HomeIntent.ShowShareMessageEditBottomSheet -> showBottomSheet()
             is HomeIntent.HideShareMessageEditBottomSheet -> hideBottomSheet()
             is HomeIntent.PullToRefresh -> refreshHomeData()
-            is HomeIntent.ClickBalanceGameOptionButton -> submitBalanceGameOption(
-                balanceGameOptionState = intent.option
-            )
-
-            is HomeIntent.ClickBalanceGameResultButton -> checkBalanceGameResult()
+            is HomeIntent.ClickBalanceGameOptionButton -> submitBalanceGameOption(balanceGameOptionState = intent.option)
             is HomeIntent.ChangeBalanceGameCardState -> changeBalanceGameCardState()
-            HomeIntent.LoadDataOnStart -> loadDataOnStart()
+            is HomeIntent.LoadDataOnStart -> loadDataOnStart()
         }
     }
 
@@ -98,7 +87,6 @@ class HomeViewModel(
 
             reduce {
                 copy(
-                    isBalanceGameCardRotated = false,
                     isLoading = false
                 )
             }
@@ -167,7 +155,6 @@ class HomeViewModel(
                             )
                         }.toImmutableList()
                     ),
-                    balanceGameCardState = HomeState.BalanceGameCardState.IDLE,
                     myChoiceOption =
                         BalanceGameOptionState(
                             id = todayBalanceGame.myChoice?.optionId ?: 0L,
@@ -204,14 +191,6 @@ class HomeViewModel(
                         ),
                 )
             }
-        }
-    }
-
-    private fun checkBalanceGameResult() {
-        reduce {
-            copy(
-                isBalanceGameCardRotated = !isBalanceGameCardRotated
-            )
         }
     }
 

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Quiz.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Quiz.kt
@@ -2,7 +2,6 @@ package com.whatever.caramel.feature.home.components
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -27,11 +26,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,20 +50,14 @@ import com.whatever.caramel.core.designsystem.themes.CaramelTheme
 import com.whatever.caramel.core.domain.vo.user.Gender
 import com.whatever.caramel.feature.home.mvi.BalanceGameOptionState
 import com.whatever.caramel.feature.home.mvi.HomeState
-import io.github.aakira.napier.Napier
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import kotlin.math.floor
 
 internal fun LazyListScope.Quiz(
-    rotated: Boolean,
     myNickname: String,
     myGender: Gender,
     partnerNickname: String,
@@ -79,21 +69,11 @@ internal fun LazyListScope.Quiz(
     balanceGameAnswerState: HomeState.BalanceGameAnswerState,
     balanceGameCardState: HomeState.BalanceGameCardState,
     onOptionClick: (BalanceGameOptionState) -> Unit,
-    onClickResult: () -> Unit,
     onChangeCardState: () -> Unit,
 ) {
     item(key = "Quiz") {
         val rotation = remember { Animatable(0f) }
-
-        LaunchedEffect(rotated) {
-            if (rotated) {
-                rotation.snapTo(0f)
-                rotation.animateTo(
-                    targetValue = rotation.value + 180f,
-                    animationSpec = tween(durationMillis = 1000)
-                )
-            }
-        }
+        val scope = rememberCoroutineScope()
 
         LaunchedEffect(Unit) {
             snapshotFlow { rotation.value >= 90f }
@@ -164,7 +144,14 @@ internal fun LazyListScope.Quiz(
                             balanceGameAnswerState = balanceGameAnswerState,
                             myChoiceOption = myChoiceOption,
                             onClickOption = onOptionClick,
-                            onClickResult = onClickResult
+                            onClickResult = {
+                                scope.launch {
+                                    rotation.animateTo(
+                                        targetValue = rotation.value + 180f,
+                                        animationSpec = tween(durationMillis = 1000)
+                                    )
+                                }
+                            }
                         )
                     }
                     HomeState.BalanceGameCardState.CONFIRM -> {

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeIntent.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeIntent.kt
@@ -23,8 +23,6 @@ sealed interface HomeIntent : UiIntent {
 
     data class ClickBalanceGameOptionButton(val option: BalanceGameOptionState) : HomeIntent
 
-    data object ClickBalanceGameResultButton : HomeIntent
-
     data object ChangeBalanceGameCardState : HomeIntent
 
 }

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeState.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeState.kt
@@ -16,7 +16,6 @@ data class HomeState(
     val todos: List<TodoState> = emptyList(),
     val isShowBottomSheet: Boolean = false,
     val isLoading: Boolean = false,
-    val isBalanceGameCardRotated: Boolean = false,
     val balanceGameState: BalanceGameState = BalanceGameState(),
     val balanceGameCardState: BalanceGameCardState = BalanceGameCardState.IDLE,
     val myChoiceOption: BalanceGameOptionState = BalanceGameOptionState(),


### PR DESCRIPTION
## 작업한 내용
- 홈 화면의 밸런스 게임 결과를 확인 한 후, 다른 화면으로 이동했다가 홈 화면 재진입 시 애니메이션이 동작하던 오류 수정

https://github.com/user-attachments/assets/0be91a92-16c0-46da-818e-350a14c3e186