### PR TITLE
[QA] 메모 리스트의 태그를 1줄로 변경

### DIFF
--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/MemoItem.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/MemoItem.kt
@@ -92,6 +92,7 @@ internal fun MemoItem(
                 )
                 Text(
                     text = categoriesText,
+                    maxLines = 1,
                     style = CaramelTheme.typography.label1.regular,
                     color = CaramelTheme.color.text.secondary,
                     overflow = TextOverflow.Ellipsis


### PR DESCRIPTION
## 작업한 내용
- 메모 리스트에서의 태그가 길어지는 경우 1줄로 변경
![image](https://github.com/user-attachments/assets/f540ba74-4aa2-46b3-b445-092941c93cd5)



