### PR TITLE
[FIX] 메모 작성 후 리프레시가 될때 메모 리스트를 2번 불러오는 현상 수정

### DIFF
--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoViewModel.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoViewModel.kt
@@ -79,6 +79,7 @@ class MemoViewModel(
     }
 
     private fun loadPagingData() {
+        if (currentState.isMemoLoading) return
         if (currentState.cursor == null && currentState.memos.isNotEmpty()) return
         getMemos()
     }


### PR DESCRIPTION
## 작업한 내용
- 간헐적으로 initialize와 paging을 동시에 호출하기에 중복 리스트가 발생했습니다.
- 페이징의 경우 메모 로딩을 진행하지 않고 데이터를 불러오기에 isMemoLoading값으로 페이징 데이터 추가 요청을 제외하였습니다.