### PR TITLE
[QA] 삭제된 메모 수정/저장 시, 메모 조회시 삭제된 컨텐츠에 대해 Dialog 뜨도록 수정

### DIFF
--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/exception/code/ContentErrorCode.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/exception/code/ContentErrorCode.kt
@@ -1,0 +1,7 @@
+package com.whatever.caramel.core.domain.exception.code
+
+data object ContentErrorCode {
+    private const val PREFIX = "Content"
+
+    const val CONTENT_NOT_FOUND = PREFIX + "005"
+} 

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/exception/code/ScheduleErrorCode.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/exception/code/ScheduleErrorCode.kt
@@ -1,0 +1,7 @@
+package com.whatever.caramel.core.domain.exception.code
+
+data object ScheduleErrorCode {
+    private const val PREFIX = "SCHEDULE"
+
+    const val SCHEDULE_NOT_FOUND = PREFIX + "003"
+} 

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailRoute.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailRoute.kt
@@ -68,4 +68,14 @@ internal fun ContentDetailRoute(
             DefaultCaramelDialogLayout()
         }
     }
+
+    CaramelDialog(
+        show = state.showDeletedContentDialog,
+        title = "삭제된 메모에요",
+        mainButtonText = "확인",
+        onDismissRequest = { viewModel.intent(ContentDetailIntent.DismissDeletedContentDialog) },
+        onMainButtonClick = { viewModel.intent(ContentDetailIntent.DismissDeletedContentDialog) }
+    ) {
+        DefaultCaramelDialogLayout()
+    }
 } 

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/mvi/ContentDetailIntent.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/mvi/ContentDetailIntent.kt
@@ -9,5 +9,6 @@ sealed interface ContentDetailIntent : UiIntent {
     data object ClickDeleteButton : ContentDetailIntent
     data object ClickConfirmDeleteDialogButton : ContentDetailIntent
     data object ClickCancelDeleteDialogButton : ContentDetailIntent
+    data object DismissDeletedContentDialog : ContentDetailIntent
     data object LoadDataOnStart : ContentDetailIntent
 } 

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/mvi/ContentDetailState.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/mvi/ContentDetailState.kt
@@ -17,6 +17,7 @@ data class ContentDetailState(
     val memoDetail: Memo? = null,
     val scheduleDetail: ScheduleDetail? = null,
     val showDeleteConfirmDialog: Boolean = false,
+    val showDeletedContentDialog: Boolean = false,
     val linkMetaDataList: ImmutableList<LinkMetaData> = persistentListOf(),
     val isLoadingLinkPreview: Boolean = false,
 ) : UiState {

--- a/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditRoute.kt
+++ b/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditRoute.kt
@@ -25,6 +25,10 @@ fun ContentEditRoute(
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is ContentEditSideEffect.NavigateBack -> popBackStack()
+                is ContentEditSideEffect.NavigateBackToContentList -> {
+                    popBackStack()
+                    popBackStack()
+                }
                 is ContentEditSideEffect.ShowErrorSnackBar -> {
                     showSnackbarMessage(
                         snackbarHostState = snackbarHostState,
@@ -63,6 +67,16 @@ fun ContentEditRoute(
         onMainButtonClick = { viewModel.intent(ContentEditIntent.ConfirmDeleteDialog) },
         onSubButtonClick = { viewModel.intent(ContentEditIntent.DismissDeleteDialog) }
     ) {
-        DefaultCaramelDialogLayout() // Or your custom layout
+        DefaultCaramelDialogLayout()
+    }
+
+    CaramelDialog(
+        show = state.showDeletedContentDialog,
+        title = "삭제된 메모에요",
+        mainButtonText = "확인",
+        onDismissRequest = { viewModel.intent(ContentEditIntent.DismissDeletedContentDialog) },
+        onMainButtonClick = { viewModel.intent(ContentEditIntent.DismissDeletedContentDialog) }
+    ) {
+        DefaultCaramelDialogLayout()
     }
 }

--- a/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/mvi/ContentEditIntent.kt
+++ b/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/mvi/ContentEditIntent.kt
@@ -14,6 +14,7 @@ sealed interface ContentEditIntent : UiIntent {
     data object ConfirmExitDialog : ContentEditIntent
     data object DismissDeleteDialog : ContentEditIntent
     data object ConfirmDeleteDialog : ContentEditIntent
+    data object DismissDeletedContentDialog : ContentEditIntent
     data class ClickTag(val tag: Tag) : ContentEditIntent
     data object ClickDate : ContentEditIntent
     data object ClickTime : ContentEditIntent

--- a/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/mvi/ContentEditSideEffect.kt
+++ b/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/mvi/ContentEditSideEffect.kt
@@ -4,5 +4,6 @@ import com.whatever.caramel.core.viewmodel.UiSideEffect
 
 sealed interface ContentEditSideEffect : UiSideEffect {
     data object NavigateBack : ContentEditSideEffect
+    data object NavigateBackToContentList : ContentEditSideEffect
     data class ShowErrorSnackBar(val code: String, val message: String? = null) : ContentEditSideEffect
 } 

--- a/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/mvi/ContentEditState.kt
+++ b/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/mvi/ContentEditState.kt
@@ -25,6 +25,7 @@ data class ContentEditState(
     val dateTime: LocalDateTime = DateUtil.todayLocalDateTime(),
     val showExitConfirmDialog: Boolean = false,
     val showDeleteConfirmDialog: Boolean = false,
+    val showDeletedContentDialog: Boolean = false,
 
     ) : UiState {
 


### PR DESCRIPTION
## 관련 이슈
- https://www.notion.so/given-dragon/Dialog-207870f222b9809b96c4dca5814fb5e3?source=copy_link
- https://www.notion.so/given-dragon/205870f222b9800f856ad23f358e8982?source=copy_link

## 작업한 내용
- 컨텐츠 조회/삭제
- 컨텐츠 수정화면에서 조회/수정/삭제
에 대해서 Dialog 처리