### PR TITLE
[FIX] 커플 시작일 수정 상단 이미지 크기 적용

### DIFF
--- a/feature/profile/edit/src/commonMain/kotlin/com/whatever/caramel/feature/profile/edit/component/EditStartDate.kt
+++ b/feature/profile/edit/src/commonMain/kotlin/com/whatever/caramel/feature/profile/edit/component/EditStartDate.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -34,6 +35,7 @@ internal fun EditStartDate(
         verticalArrangement = Arrangement.spacedBy(CaramelTheme.spacing.xl)
     ) {
         Icon(
+            modifier = Modifier.size(width = 68.dp, height = 32.dp),
             painter = painterResource(Resources.Image.img_couple_on_ground),
             contentDescription = null,
             tint = Color.Unspecified


### PR DESCRIPTION
## 작업한 내용
- #136 를 적용하며 설정 > 커플 시작일 수정의 상단 이미지 크기 조정

![image](https://github.com/user-attachments/assets/9b9edd57-0b7b-461d-921d-1cf7fd3f1cdb)
