### PR TITLE
[Fix] 최초 커플 연결 이후 CoupleId로 인한 홈 화면 진입 오류 수정

### DIFF
--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
@@ -43,7 +43,9 @@ internal fun CaramelNavHost(
     ) {
         with(navHostController) {
             splashScreen(
-                navigateToStartDestination = { onIntent(AppIntent.NavigateToStartDestination) },
+                navigateToStartDestination = { userStatus ->
+                    onIntent(AppIntent.NavigateToStartDestination(userStatus = userStatus))
+                },
                 navigateToLogin = {
                     navigateToLogin {
                         popUpTo(route = SplashRoute) {

--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
@@ -55,7 +55,9 @@ internal fun CaramelNavHost(
                 },
             )
             loginScreen(
-                navigateToStartDestination = { onIntent(AppIntent.NavigateToStartDestination) },
+                navigateToStartDestination = { userStatus ->
+                    onIntent(AppIntent.NavigateToStartDestination(userStatus = userStatus))
+                },
             )
             createProfileScreen(
                 navigateToLogin = {

--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
@@ -67,7 +67,9 @@ internal fun CaramelNavHost(
                         }
                     }
                 },
-                navigateToStartDestination = { onIntent(AppIntent.NavigateToStartDestination) }
+                navigateToStartDestination = { userStatus ->
+                    onIntent(AppIntent.NavigateToStartDestination(userStatus = userStatus))
+                },
             )
             connectingScreen(
                 navigateToMain = { navigateToMain() }

--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelViewModel.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelViewModel.kt
@@ -17,7 +17,6 @@ import com.whatever.caramel.mvi.AppState
 import kotlinx.coroutines.launch
 
 class CaramelViewModel(
-    private val getUserStatusUseCase: GetUserStatusUseCase,
     private val connectCoupleUseCase: ConnectCoupleUseCase,
     private val deepLinkHandler: DeepLinkHandler,
     savedStateHandle: SavedStateHandle
@@ -64,15 +63,13 @@ class CaramelViewModel(
 
     override suspend fun handleIntent(intent: AppIntent) {
         when(intent) {
-            is AppIntent.NavigateToStartDestination -> startDestination()
+            is AppIntent.NavigateToStartDestination -> startDestination(userStatus = intent.userStatus)
             is AppIntent.CloseErrorDialog -> reduce { copy(isShowErrorDialog = false) }
         }
     }
 
-    private suspend fun startDestination() {
+    private suspend fun startDestination(userStatus: UserStatus) {
         launch {
-            val userStatus = getUserStatusUseCase()
-
             when (userStatus) {
                 UserStatus.NONE -> postSideEffect(AppSideEffect.NavigateToLogin)
                 UserStatus.NEW -> postSideEffect(AppSideEffect.NavigateToCreateProfile)

--- a/app/src/commonMain/kotlin/com/whatever/caramel/mvi/AppIntent.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/mvi/AppIntent.kt
@@ -1,10 +1,11 @@
 package com.whatever.caramel.mvi
 
+import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.core.viewmodel.UiIntent
 
 sealed interface AppIntent : UiIntent {
 
-    data object NavigateToStartDestination : AppIntent
+    data class NavigateToStartDestination(val userStatus: UserStatus) : AppIntent
 
     data object CloseErrorDialog : AppIntent
 

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/auth/SignInWithSocialPlatformUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/auth/SignInWithSocialPlatformUseCase.kt
@@ -15,11 +15,12 @@ class SignInWithSocialPlatformUseCase(
     suspend operator fun invoke(
         idToken: String,
         socialLoginType: SocialLoginType
-    ) {
+    ): UserStatus {
         val signInUserAuth: UserAuth = authRepository.loginWithSocialPlatform(
             idToken = idToken,
             socialLoginType = socialLoginType
         )
+
         with(signInUserAuth) {
             authRepository.saveTokens(authToken = authToken)
             userRepository.setUserStatus(userStatus)
@@ -28,5 +29,7 @@ class SignInWithSocialPlatformUseCase(
                 coupleRepository.setCoupleId(coupleId = coupleId)
             }
         }
+
+        return signInUserAuth.userStatus
     }
 }

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/couple/GetCoupleRelationshipInfoUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/couple/GetCoupleRelationshipInfoUseCase.kt
@@ -7,7 +7,14 @@ class GetCoupleRelationshipInfoUseCase(
     private val coupleRepository: CoupleRepository
 ) {
     suspend operator fun invoke(): CoupleRelationship {
-        val savedCoupleId = coupleRepository.getCoupleId()
-        return coupleRepository.getCoupleRelationshipInfo(savedCoupleId)
+        val coupleId = if (coupleRepository.getCoupleId() == 0L) { // @ham2174 TODO : 커플 아이디 인메모리 저장 형식으로 변경
+            val coupleInfo = coupleRepository.getCoupleInfo() // 커플 정보 획득
+            coupleRepository.setCoupleId(coupleId = coupleInfo.id) // 커플 아이디 저장
+            coupleInfo.id
+        } else {
+            coupleRepository.getCoupleId()
+        }
+
+        return coupleRepository.getCoupleRelationshipInfo(coupleId = coupleId)
     }
 }

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/user/CreateUserProfileUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/user/CreateUserProfileUseCase.kt
@@ -14,19 +14,19 @@ class CreateUserProfileUseCase(
         gender: Gender,
         agreementServiceTerms: Boolean,
         agreementPrivacyPolicy: Boolean
-    ) {
-        UserValidator.checkNicknameValidate(nickname)
-            .onSuccess {
-                val createProfileResult = userRepository.createUserProfile(
-                    nickname = nickname,
-                    birthDay = birthDay,
-                    gender = gender,
-                    agreementServiceTerms = agreementServiceTerms,
-                    agreementPrivacyPolicy = agreementPrivacyPolicy
-                )
-                userRepository.setUserStatus(createProfileResult.userStatus)
-            }.onFailure {
-                throw it
-            }
+    ): UserStatus {
+        val validatedNickname = UserValidator.checkNicknameValidate(nickname).getOrThrow()
+
+        val createProfileResult = userRepository.createUserProfile(
+            nickname = validatedNickname,
+            birthDay = birthDay,
+            gender = gender,
+            agreementServiceTerms = agreementServiceTerms,
+            agreementPrivacyPolicy = agreementPrivacyPolicy
+        )
+        val userStatus = createProfileResult.userStatus
+        userRepository.setUserStatus(status = userStatus)
+
+        return userStatus
     }
 }

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/user/RefreshUserSessionUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/user/RefreshUserSessionUseCase.kt
@@ -8,12 +8,15 @@ class RefreshUserSessionUseCase(
     private val authRepository: AuthRepository,
     private val userRepository: UserRepository
 ) {
-    suspend operator fun invoke() {
+    suspend operator fun invoke(): UserStatus {
         val localSavedToken = authRepository.getAuthToken()
         val newToken = authRepository.refreshAuthToken(localSavedToken)
         authRepository.saveTokens(newToken)
 
         val userInfo = userRepository.getUserInfo()
-        userRepository.setUserStatus(status = userInfo.userStatus)
+        val userStatus = userInfo.userStatus
+        userRepository.setUserStatus(status = userStatus)
+
+        return userStatus
     }
 }

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/validator/UserValidator.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/validator/UserValidator.kt
@@ -39,7 +39,7 @@ object UserValidator {
      * @param input 닉네임 입력값
      * @return 검증에 대한 Result 객체
      * */
-    fun checkNicknameValidate(input : String) : Result<Unit> {
+    fun checkNicknameValidate(input : String) : Result<String> {
         return when {
             input.length > NICKNAME_MAX_LENGTH -> Result.failure(
                 CaramelException(
@@ -55,7 +55,7 @@ object UserValidator {
                     debugMessage = "Nickname should only contain English letters, numbers, and Korean characters."
                 )
             )
-            else -> Result.success(Unit)
+            else -> Result.success(input)
         }
     }
 

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginRoute.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginRoute.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.whatever.caramel.core.domain.vo.auth.SocialLoginType
+import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.feature.login.mvi.LoginIntent
 import com.whatever.caramel.feature.login.mvi.LoginSideEffect
 import com.whatever.caramel.feature.login.social.SocialAuthenticator
@@ -33,7 +34,7 @@ internal fun LoginRoute(
     viewModel: LoginViewModel = koinViewModel(),
     kakaoAuthenticator: SocialAuthenticator<KakaoUser> = koinInject<KakaoAuthProvider>().get(),
     appleAuthenticator: SocialAuthenticator<AppleUser>? = if (Platform.isIos) koinInject<AppleAuthProvider>().get() else null,
-    navigateToStartDestination: () -> Unit
+    navigateToStartDestination: (UserStatus) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
@@ -105,7 +106,7 @@ internal fun LoginRoute(
             when (sideEffect) {
                 // @RyuSw-cs 2025.04.01 FIXME : 로컬에서 발생하면 코드, 서버라면 메세지를 받고 있어 분기 처리 필요
                 is LoginSideEffect.ShowErrorSnackBar -> Napier.e { "Error: ${sideEffect.message}" }
-                is LoginSideEffect.NavigateToStartDestination -> navigateToStartDestination()
+                is LoginSideEffect.NavigateToStartDestination -> navigateToStartDestination(sideEffect.userStatus)
             }
         }
     }

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginViewModel.kt
@@ -85,12 +85,12 @@ class LoginViewModel(
         socialLoginType: SocialLoginType
     ) {
         launch {
-            signInWithSocialPlatformUseCase(
+            val userStatus = signInWithSocialPlatformUseCase(
                 idToken = idToken,
                 socialLoginType = socialLoginType
             )
             fcmTokenProvider.updateToken()
-            postSideEffect(LoginSideEffect.NavigateToStartDestination)
+            postSideEffect(LoginSideEffect.NavigateToStartDestination(userStatus = userStatus))
         }
     }
 }

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/mvi/LoginSideEffect.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/mvi/LoginSideEffect.kt
@@ -1,10 +1,11 @@
 package com.whatever.caramel.feature.login.mvi
 
+import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.core.viewmodel.UiSideEffect
 
 sealed interface LoginSideEffect : UiSideEffect {
 
-    data object NavigateToStartDestination : LoginSideEffect
+    data class NavigateToStartDestination(val userStatus: UserStatus) : LoginSideEffect
 
     data class ShowErrorSnackBar(val code: String, val message: String? = null) : LoginSideEffect
 

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/navigation/LoginNavigation.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/navigation/LoginNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.compose.composable
+import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.feature.login.LoginRoute
 import kotlinx.serialization.Serializable
 
@@ -22,7 +23,7 @@ fun NavController.navigateToLogin(
 }
 
 fun NavGraphBuilder.loginScreen(
-    navigateToStartDestination: () -> Unit
+    navigateToStartDestination: (UserStatus) -> Unit
 ) {
     composable<LoginRoute>(
         enterTransition = {

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateRoute.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateRoute.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.whatever.caramel.core.designsystem.foundations.Resources
 import com.whatever.caramel.core.designsystem.util.HapticController
 import com.whatever.caramel.core.designsystem.util.HapticStyle
+import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.feature.profile.create.mvi.ProfileCreateIntent
 import com.whatever.caramel.feature.profile.create.mvi.ProfileCreateSideEffect
 import org.koin.compose.getKoin
@@ -22,7 +23,7 @@ import org.koin.compose.viewmodel.koinViewModel
 internal fun ProfileCreateRoute(
     viewModel: ProfileCreateViewModel = koinViewModel(),
     navigateToLogin: () -> Unit,
-    navigateToStartDestination: () -> Unit
+    navigateToStartDestination: (UserStatus) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val hapticController: HapticController = getKoin().get()
@@ -38,7 +39,7 @@ internal fun ProfileCreateRoute(
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is ProfileCreateSideEffect.NavigateToLogin -> navigateToLogin()
-                is ProfileCreateSideEffect.NavigateToStartDestination -> navigateToStartDestination()
+                is ProfileCreateSideEffect.NavigateToStartDestination -> navigateToStartDestination(sideEffect.userStatus)
                 is ProfileCreateSideEffect.NavigateToPersonalInfoTermNotion -> urlHandler.openUri(privacyPolicyUrl)
                 is ProfileCreateSideEffect.NavigateToServiceTermNotion -> urlHandler.openUri(termsOfServiceUrl)
                 is ProfileCreateSideEffect.PerformHapticFeedback -> hapticController.performImpact(HapticStyle.GestureThresholdActivate)

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateViewModel.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateViewModel.kt
@@ -71,7 +71,7 @@ class ProfileCreateViewModel(
             }
         } else {
             launch {
-                createUserProfileUseCase(
+                val userStatus = createUserProfileUseCase(
                     nickname = currentState.nickname,
                     birthDay = createDateString(
                         currentState.birthday.year,
@@ -82,7 +82,7 @@ class ProfileCreateViewModel(
                     agreementServiceTerms = currentState.isServiceTermChecked,
                     agreementPrivacyPolicy = currentState.isPersonalInfoTermChecked
                 )
-                postSideEffect(ProfileCreateSideEffect.NavigateToStartDestination)
+                postSideEffect(ProfileCreateSideEffect.NavigateToStartDestination(userStatus = userStatus))
             }
         }
     }

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/mvi/ProfileCreateSideEffect.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/mvi/ProfileCreateSideEffect.kt
@@ -1,12 +1,13 @@
 package com.whatever.caramel.feature.profile.create.mvi
 
+import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.core.viewmodel.UiSideEffect
 
 sealed interface ProfileCreateSideEffect : UiSideEffect {
 
     data object NavigateToLogin : ProfileCreateSideEffect
 
-    data object NavigateToStartDestination : ProfileCreateSideEffect
+    data class NavigateToStartDestination(val userStatus: UserStatus) : ProfileCreateSideEffect
 
     data object NavigateToServiceTermNotion : ProfileCreateSideEffect
 

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/navigation/ProfileNavigation.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/navigation/ProfileNavigation.kt
@@ -2,12 +2,11 @@ package com.whatever.caramel.feature.profile.create.navigation
 
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.slideOut
-import androidx.compose.ui.unit.IntOffset
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.compose.composable
+import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.feature.profile.create.ProfileCreateRoute
 import kotlinx.serialization.Serializable
 
@@ -22,7 +21,7 @@ fun NavController.navigateToCreateProfile(builder: NavOptionsBuilder.() -> Unit 
 
 fun NavGraphBuilder.createProfileScreen(
     navigateToLogin: () -> Unit,
-    navigateToStartDestination: () -> Unit
+    navigateToStartDestination: (UserStatus) -> Unit
 ) {
     composable<ProfileCreateRoute>(
         enterTransition = {

--- a/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/SplashRoute.kt
+++ b/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/SplashRoute.kt
@@ -4,13 +4,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.feature.splash.mvi.SplashSideEffect
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 internal fun SplashRoute(
     viewModel: SplashViewModel = koinViewModel(),
-    navigateToStartDestination: () -> Unit,
+    navigateToStartDestination: (UserStatus) -> Unit,
     navigateToLogin: () -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -19,7 +20,7 @@ internal fun SplashRoute(
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is SplashSideEffect.NavigateToLogin -> navigateToLogin()
-                is SplashSideEffect.NavigateToStartDestination -> navigateToStartDestination()
+                is SplashSideEffect.NavigateToStartDestination -> navigateToStartDestination(sideEffect.userStatus)
             }
         }
     }

--- a/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/SplashViewModel.kt
+++ b/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/SplashViewModel.kt
@@ -19,8 +19,8 @@ class SplashViewModel(
         launch {
             delay(1000L)
             deepLinkHandler.runningApp()
-            refreshUserSessionUseCase()
-            postSideEffect(SplashSideEffect.NavigateToStartDestination)
+            val userStatus = refreshUserSessionUseCase()
+            postSideEffect(SplashSideEffect.NavigateToStartDestination(userStatus = userStatus))
         }
     }
 

--- a/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/mvi/SplashSideEffect.kt
+++ b/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/mvi/SplashSideEffect.kt
@@ -1,10 +1,11 @@
 package com.whatever.caramel.feature.splash.mvi
 
+import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.core.viewmodel.UiSideEffect
 
 sealed interface SplashSideEffect : UiSideEffect {
 
-    data object NavigateToStartDestination : SplashSideEffect
+    data class NavigateToStartDestination(val userStatus: UserStatus) : SplashSideEffect
 
     data object NavigateToLogin : SplashSideEffect
 

--- a/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/navigation/SplashNavigation.kt
+++ b/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/navigation/SplashNavigation.kt
@@ -2,6 +2,7 @@ package com.whatever.caramel.feature.splash.navigation
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.feature.splash.SplashRoute
 import kotlinx.serialization.Serializable
 
@@ -10,7 +11,7 @@ data object SplashRoute
 
 fun NavGraphBuilder.splashScreen(
     navigateToLogin: () -> Unit,
-    navigateToStartDestination: () -> Unit
+    navigateToStartDestination: (UserStatus) -> Unit
 ) {
     composable<SplashRoute> {
         SplashRoute(


### PR DESCRIPTION
## 작업한 내용
- 스플래쉬, 로그인, 프로필 생성 이후 홈 화면 진입 로직 수정

## PR 포인트
- coupleId 인메모리 저장 로직은 이슈 등록 후 수정 예정 ce536cad33ff6c42fac5af2ff72d21f833953c20
- 수정해야될 범위 : `CoupleRepository` 에서 coupleId가 필요한 기능들