### PR TITLE
[QA] 캘린더에서 일정 생성 시 오늘 일정이 나오는 현상 수정

### DIFF
--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
@@ -126,7 +126,13 @@ internal fun CaramelNavHost(
                 navigateToTodoDetail = { contentId, contentType ->
                     navigateToContentDetail(contentId = contentId, type = contentType)
                 },
-                navigateToCreateTodo = { navigateToContentCreate(contentType = it) }
+                navigateToCreateTodo = { navigateToContentCreate(contentType = it) },
+                navigateToCreateSchedule = { contentType, dateTimeString ->
+                    navigateToContentCreate(
+                        contentType = contentType,
+                        dateTimeString = dateTimeString
+                    )
+                }
             )
             contentEditScreen(
                 popBackStack = { popBackStack() }

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarRoute.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarRoute.kt
@@ -12,7 +12,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 internal fun CalendarRoute(
     viewModel: CalendarViewModel = koinViewModel(),
-    navigateToCreateTodo: (ContentType) -> Unit,
+    navigateToCreateTodo: (ContentType, String) -> Unit,
     navigateToTodoDetail: (Long, ContentType) -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -21,7 +21,7 @@ internal fun CalendarRoute(
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is CalendarSideEffect.NavigateToTodoDetail -> navigateToTodoDetail(sideEffect.id, sideEffect.contentType)
-                is CalendarSideEffect.NavigateToAddSchedule -> navigateToCreateTodo(ContentType.CALENDAR)
+                is CalendarSideEffect.NavigateToAddSchedule -> navigateToCreateTodo(ContentType.CALENDAR, sideEffect.dateTimeString)
                 is CalendarSideEffect.OpenWebView -> uriHandler.openUri(sideEffect.url)
             }
         }

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarScreen.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarScreen.kt
@@ -180,11 +180,7 @@ internal fun CalendarScreen(
                                 BottomSheetTodoListHeader(
                                     date = schedule.date,
                                     onClickAddSchedule = {
-                                        onIntent(
-                                            CalendarIntent.ClickAddScheduleButton(
-                                                it.toString()
-                                            )
-                                        )
+                                        onIntent(CalendarIntent.ClickAddScheduleButton(schedule.date))
                                     },
                                     isToday = schedule.date == state.today,
                                     isEmpty = schedule.todos.isEmpty(),

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarViewModel.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarViewModel.kt
@@ -20,6 +20,7 @@ import com.whatever.caramel.feature.calendar.mvi.DaySchedule
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atTime
 import kotlinx.datetime.number
 
 class CalendarViewModel(
@@ -57,9 +58,7 @@ class CalendarViewModel(
             is CalendarIntent.ClickDatePicker -> showCalendarDatePicker()
             is CalendarIntent.ToggleCalendarBottomSheet -> toggleCalendarBottomSheet(intent.sheetState)
             is CalendarIntent.ClickAddScheduleButton -> postSideEffect(
-                CalendarSideEffect.NavigateToAddSchedule(
-                    intent.date
-                )
+                CalendarSideEffect.NavigateToAddSchedule(intent.date.atTime(hour = 0, minute = 0).toString())
             )
 
             is CalendarIntent.ClickTodoItemInBottomSheet -> postSideEffect(

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/mvi/CalendarIntent.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/mvi/CalendarIntent.kt
@@ -8,7 +8,7 @@ sealed interface CalendarIntent : UiIntent {
     data object ClickDatePicker : CalendarIntent
     data object ClickDatePickerOutSide : CalendarIntent
     data object ClickOutSideBottomSheet : CalendarIntent
-    data class ClickAddScheduleButton(val date : String) : CalendarIntent
+    data class ClickAddScheduleButton(val date : LocalDate) : CalendarIntent
     data class ClickTodoItemInBottomSheet(val todoId : Long) : CalendarIntent
     data class ClickTodoUrl(val url : String?) : CalendarIntent
     data class ToggleCalendarBottomSheet(val sheetState: BottomSheetState) : CalendarIntent

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/mvi/CalendarSideEffect.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/mvi/CalendarSideEffect.kt
@@ -6,5 +6,5 @@ import com.whatever.caramel.core.viewmodel.UiSideEffect
 sealed interface CalendarSideEffect : UiSideEffect {
     data class NavigateToTodoDetail(val id: Long, val contentType: ContentType) : CalendarSideEffect
     data class OpenWebView(val url: String) : CalendarSideEffect
-    data class NavigateToAddSchedule(val date: String) : CalendarSideEffect
+    data class NavigateToAddSchedule(val dateTimeString: String) : CalendarSideEffect
 }

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/navigation/CalendarNavigation.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/navigation/CalendarNavigation.kt
@@ -19,12 +19,12 @@ fun NavHostController.navigateToCalendar(builder: NavOptionsBuilder.() -> Unit) 
 }
 
 fun NavGraphBuilder.calendarContent(
-    navigateToCreateTodo: (ContentType) -> Unit,
+    navigateToCreateSchedule: (ContentType, String) -> Unit,
     navigateToTodoDetail: (Long, ContentType) -> Unit,
 ) {
     composable<CalendarRoute> {
         CalendarRoute(
-            navigateToCreateTodo = navigateToCreateTodo,
+            navigateToCreateTodo = navigateToCreateSchedule,
             navigateToTodoDetail = navigateToTodoDetail,
         )
     }

--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
@@ -11,6 +11,7 @@ import com.whatever.caramel.core.domain.vo.content.ContentParameterType
 import com.whatever.caramel.core.domain.vo.content.ContentType
 import com.whatever.caramel.core.domain.vo.memo.MemoParameter
 import com.whatever.caramel.core.ui.content.CreateMode
+import com.whatever.caramel.core.util.DateUtil
 import com.whatever.caramel.core.util.copy
 import com.whatever.caramel.core.viewmodel.BaseViewModel
 import com.whatever.caramel.feature.content.create.mvi.ContentCreateIntent
@@ -20,6 +21,7 @@ import com.whatever.caramel.feature.content.create.navigation.ContentCreateRoute
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
@@ -40,11 +42,16 @@ class ContentCreateViewModel(
 
     override fun createInitialState(savedStateHandle: SavedStateHandle): ContentCreateState {
         val arguments = savedStateHandle.toRoute<ContentCreateRoute>()
+        val dateTime =
+            if (arguments.dateTimeString.isEmpty()) DateUtil.todayLocalDateTime() else LocalDateTime.parse(
+                arguments.dateTimeString
+            )
         return ContentCreateState(
             createMode = when (arguments.contentType) {
                 ContentType.MEMO -> CreateMode.MEMO
                 ContentType.CALENDAR -> CreateMode.CALENDAR
-            }
+            },
+            dateTime = dateTime
         )
     }
 

--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/navigation/ContentCreateNavigation.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/navigation/ContentCreateNavigation.kt
@@ -12,16 +12,19 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ContentCreateRoute(
-    val contentType: ContentType
+    val contentType: ContentType,
+    val dateTimeString: String
 )
 
 fun NavHostController.navigateToContentCreate(
     navOptions: NavOptions? = null,
-    contentType: ContentType
+    contentType: ContentType,
+    dateTimeString: String = ""
 ) {
     navigate(
         route = ContentCreateRoute(
-            contentType = contentType
+            contentType = contentType,
+            dateTimeString = dateTimeString
         ),
         navOptions = navOptions
     )

--- a/feature/main/src/commonMain/kotlin/com/whatever/caramel/feature/main/MainRoute.kt
+++ b/feature/main/src/commonMain/kotlin/com/whatever/caramel/feature/main/MainRoute.kt
@@ -40,6 +40,7 @@ internal fun MainRoute(
     navigateToStaredCoupleDay: () -> Unit,
     navigateToTodoDetail: (Long, ContentType) -> Unit,
     navigateToCreateTodo: (ContentType) -> Unit,
+    navigateToCreateSchedule : (ContentType, String) -> Unit,
 ) {
     val hapticFeedback = LocalHapticFeedback.current
     val mainNavHostController = rememberNavController()
@@ -110,7 +111,7 @@ internal fun MainRoute(
                 navigateToCreateTodo = navigateToCreateTodo
             )
             calendarContent(
-                navigateToCreateTodo = navigateToCreateTodo,
+                navigateToCreateSchedule = navigateToCreateSchedule,
                 navigateToTodoDetail = navigateToTodoDetail,
             )
             memoContent(

--- a/feature/main/src/commonMain/kotlin/com/whatever/caramel/feature/main/navigation/MainNavigation.kt
+++ b/feature/main/src/commonMain/kotlin/com/whatever/caramel/feature/main/navigation/MainNavigation.kt
@@ -25,6 +25,7 @@ fun NavGraphBuilder.mainGraph(
     navigateToStaredCoupleDay: () -> Unit,
     navigateToTodoDetail: (Long, ContentType) -> Unit,
     navigateToCreateTodo: (ContentType) -> Unit,
+    navigateToCreateSchedule: (ContentType, String) -> Unit,
 ) {
     composable<MainRoute>(
         exitTransition = { ExitTransition.None },
@@ -35,7 +36,8 @@ fun NavGraphBuilder.mainGraph(
             navigateToSetting = navigateToSetting,
             navigateToStaredCoupleDay = navigateToStaredCoupleDay,
             navigateToTodoDetail = navigateToTodoDetail,
-            navigateToCreateTodo = navigateToCreateTodo
+            navigateToCreateTodo = navigateToCreateTodo,
+            navigateToCreateSchedule = navigateToCreateSchedule
         )
     }
 }


### PR DESCRIPTION
## 작업한 내용
- 캘린더 바텀시트에서 특정 일자로 일정 생성 버튼 클릭 시 오늘 날짜가 나온 현상 수정
  - LocalDateTime을 그대로 주는 경우 NavType을 알지못해 String으로 변환해서 전환
  
![image](https://github.com/user-attachments/assets/a8f770e0-247b-4c91-9948-b7f6dfce1767)


