### PR TITLE
[QA] 메모 생성 조건에 따라서 UI 조정

### DIFF
--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/MemoItem.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/MemoItem.kt
@@ -41,8 +41,8 @@ internal fun MemoItem(
     createdDateText: String,
     onClickMemoItem: (Long) -> Unit
 ) {
-    val isEmptyTitle = title.isEmpty()
-    val titleText = if (isEmptyTitle) description.replace(lineBreakRegex, "") else title
+    val isTitleOrDescriptionEmpty = title.isEmpty() || description.isEmpty()
+    val mainText = title.ifEmpty { description.replace(lineBreakRegex, "") }
 
     Column(
         modifier = modifier
@@ -57,13 +57,13 @@ internal fun MemoItem(
     ) {
         Text(
             modifier = Modifier.fillMaxWidth(),
-            text = titleText,
+            text = mainText,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             style = CaramelTheme.typography.body2.bold,
             color = CaramelTheme.color.text.primary
         )
-        if (!isEmptyTitle) {
+        if (!isTitleOrDescriptionEmpty) {
             Text(
                 modifier = Modifier.fillMaxWidth(),
                 text = description,


### PR DESCRIPTION
## 관련 이슈
- [매모탭에서 본문 미입력한 메모의 ui 조정필요](https://www.notion.so/given-dragon/ui-212870f222b98057b1dbff516d62f539)

## 작업한 내용
- 메모 생성 조건에 따른 UI 수정
  -  제목만 존재 or 내용만 존재 -> 제목 ui로 변경
- 현재 서버에서 내용만 작성한 경우 제목과 내용에 둘다 추가되기에 확인필요