### PR TITLE
[QA] 다이얼로그의 제목만 있는경우 Spacer의 위치 변경

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/components/Dialog.kt
@@ -101,8 +101,8 @@ fun CaramelDialogScope.DefaultCaramelDialogLayout() {
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         CaramelDialogTitle()
-        Spacer(modifier = Modifier.height(height = CaramelTheme.spacing.s))
         if (hasMessage) {
+            Spacer(modifier = Modifier.height(height = CaramelTheme.spacing.s))
             CaramelDialogContent()
         }
         Spacer(modifier = Modifier.height(height = CaramelTheme.spacing.xl))


### PR DESCRIPTION
## 관련 이슈
- [디자인 시스템 - 다이얼로그](https://www.notion.so/given-dragon/205870f222b980a6be18c2e6674e8435)

## 작업한 내용
- 다이얼로그의 제목과 내용이 모두 있는경우에 사이에 Spacer 추가