### PR TITLE
[QA] 메모 초기화 시 순차적으로 실행되도록 변경

### DIFF
--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoViewModel.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoViewModel.kt
@@ -44,19 +44,21 @@ class MemoViewModel(
     }
 
     private fun initialize() {
-        reduce {
-            copy(
-                isMemoLoading = true,
-                isTagLoading = true,
-                isRefreshing = false,
-                memos = persistentListOf(),
-                tags = persistentListOf(),
-                selectedTag = null,
-                cursor = null
-            )
+        launch {
+            reduce {
+                copy(
+                    isMemoLoading = true,
+                    isTagLoading = true,
+                    isRefreshing = false,
+                    memos = persistentListOf(),
+                    tags = persistentListOf(),
+                    selectedTag = null,
+                    cursor = null
+                )
+            }
+            getMemos()
+            getTags()   
         }
-        getMemos()
-        getTags()
     }
 
     private fun getTags() {


### PR DESCRIPTION
## 관련 이슈
- [다른 앱 사용하다가 다시 들어오면 메모가 안 보임](https://www.notion.so/given-dragon/211870f222b98027b705c795256d5aa5)

## 작업한 내용
- Action이 ON_START인 경우 실행되는 initialize를 순차적 실행으로 변경
  - Android는 괜찮지만 iOS의 경우 Tag가 보이지 않는 현상이 생겨서 순차로 변경하였습니다.
