### PR TITLE
[QA] Setting -> BottomSheet 하단의 navigationBarPadding에 색상 추가

### DIFF
--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -222,14 +223,18 @@ fun SettingDialogHost(
     if (isShowEditProfileBottomSheet) {
         ModalBottomSheet(
             onDismissRequest = toggleEditProfileDialog,
+            contentWindowInsets = { WindowInsets(0, 0, 0, 0) },
             dragHandle = null,
             shape = RoundedCornerShape(
                 topStart = 24.dp,
                 topEnd = 24.dp
             ),
-            scrimColor = CaramelTheme.color.alpha.primary
+            scrimColor = CaramelTheme.color.alpha.primary,
         ) {
             SettingEditProfileBottomSheet(
+                modifier = Modifier
+                    .background(color = CaramelTheme.color.background.tertiary)
+                    .navigationBarsPadding(),
                 navigateToProfileEditNickName = onClickEditNickname,
                 navigateToProfileEditBrithDay = onClickEditBrithDay
             )

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/component/BottomSheet.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/component/BottomSheet.kt
@@ -20,11 +20,12 @@ import org.jetbrains.compose.resources.painterResource
 
 @Composable
 internal fun SettingEditProfileBottomSheet(
+    modifier: Modifier = Modifier,
     navigateToProfileEditNickName : () -> Unit,
     navigateToProfileEditBrithDay : () -> Unit,
 ) {
     Column (
-        modifier = Modifier
+        modifier = modifier
             .background(color = CaramelTheme.color.background.tertiary)
             .padding(horizontal = CaramelTheme.spacing.xl)
     ){


### PR DESCRIPTION
## 관련 이슈
- [설정 - 프로필 편집](https://www.notion.so/205870f222b98003ad0beff99da5a8d6?d=67a870f222b982dc8d6583ccf98c19aa&source=copy_link)

## 작업한 내용
- 설정 > 프로필 수정의 BottomSheet의 NavigationPadding에 색상 적용