### PR TITLE
[QA] 일정 작성 이후 캘린더 진입 시 새로고침

### DIFF
--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarRoute.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarRoute.kt
@@ -4,8 +4,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.whatever.caramel.core.domain.vo.content.ContentType
+import com.whatever.caramel.core.ui.util.ObserveLifecycleEvent
+import com.whatever.caramel.feature.calendar.mvi.CalendarIntent
 import com.whatever.caramel.feature.calendar.mvi.CalendarSideEffect
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -24,6 +27,12 @@ internal fun CalendarRoute(
                 is CalendarSideEffect.NavigateToAddSchedule -> navigateToCreateTodo(ContentType.CALENDAR, sideEffect.dateTimeString)
                 is CalendarSideEffect.OpenWebView -> uriHandler.openUri(sideEffect.url)
             }
+        }
+    }
+
+    ObserveLifecycleEvent { event ->
+        if (event == Lifecycle.Event.ON_START) {
+            viewModel.intent(CalendarIntent.Initialize)
         }
     }
 

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/mvi/CalendarIntent.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/mvi/CalendarIntent.kt
@@ -4,6 +4,7 @@ import com.whatever.caramel.core.viewmodel.UiIntent
 import kotlinx.datetime.LocalDate
 
 sealed interface CalendarIntent : UiIntent {
+    data object Initialize : CalendarIntent
     data object RefreshCalendar : CalendarIntent
     data object ClickDatePicker : CalendarIntent
     data object ClickDatePickerOutSide : CalendarIntent


### PR DESCRIPTION
## 관련 이슈
- [일정이 바로 불러와지지 않음](https://www.notion.so/given-dragon/207870f222b980c891e1ecc069c10743)

## 작업한 내용
- 캘린더 화면 진입 시 설정된 년/월을 기반으로 데이터 불러오도록 변경