### PR TITLE
[FIX] 일정 조건에 따른 UI, URL 수정

### DIFF
--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Todo.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Todo.kt
@@ -7,12 +7,12 @@ data class Todo(
     val startDate: LocalDateTime,
     val endDate: LocalDateTime,
     val title: String,
-    val description: String?
+    val description: String
 ) {
     val url: String?
         get() {
-            if (description == null) return null
-            return URL_PATTERN.findAll(description).map { it.value }.firstOrNull()
+            val allContent = "$title $description"
+            return URL_PATTERN.findAll(allContent).map { it.value }.firstOrNull()
         }
 
     companion object {

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/component/bottomSheet/TodoList.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/component/bottomSheet/TodoList.kt
@@ -25,7 +25,7 @@ import org.jetbrains.compose.resources.painterResource
 internal interface CaramelBottomTodoScope {
     val id: Long
     val title: String
-    val description: String?
+    val description: String
     val url: String?
     val onClickUrl: (String?) -> Unit
     val onClickTodo: (Long) -> Unit
@@ -34,7 +34,7 @@ internal interface CaramelBottomTodoScope {
 internal class CaramelDefaultBottomTodoScope(
     override val id: Long,
     override val title: String,
-    override val description: String?,
+    override val description: String,
     override val url: String?,
     override val onClickUrl: (String?) -> Unit,
     override val onClickTodo: (Long) -> Unit
@@ -44,7 +44,7 @@ internal class CaramelDefaultBottomTodoScope(
 internal fun BottomSheetTodoItem(
     id: Long,
     title: String,
-    description: String? = null,
+    description: String,
     url: String? = null,
     onClickTodo: (Long) -> Unit = {},
     onClickUrl: (String?) -> Unit = {},
@@ -74,7 +74,7 @@ internal fun BottomSheetTodoItem(
 internal fun CaramelBottomTodoScope.DefaultBottomSheetTodoItem(
     modifier: Modifier = Modifier
 ) {
-    val hasDescription = !this.description.isNullOrEmpty()
+    val hasAll = this.title.isNotEmpty() && this.description.isNotEmpty()
     val hasUrl = !this.url.isNullOrEmpty()
 
     Column(
@@ -88,7 +88,7 @@ internal fun CaramelBottomTodoScope.DefaultBottomSheetTodoItem(
         verticalArrangement = Arrangement.spacedBy(CaramelTheme.spacing.l)
     ) {
         TodoTitle()
-        if (hasDescription) TodoDescription()
+        if (hasAll) TodoDescription()
         if (hasUrl) {
             TodoUrl()
         }
@@ -99,6 +99,7 @@ internal fun CaramelBottomTodoScope.DefaultBottomSheetTodoItem(
 internal fun CaramelBottomTodoScope.TodoTitle(
     modifier: Modifier = Modifier
 ) {
+    val mainText = this.title.ifEmpty { description }
     Text(
         modifier = modifier
             .fillMaxWidth()
@@ -107,7 +108,7 @@ internal fun CaramelBottomTodoScope.TodoTitle(
                 interactionSource = null,
                 onClick = { onClickTodo(id) }
             ),
-        text = this.title,
+        text = mainText,
         style = CaramelTheme.typography.body3.regular,
         color = CaramelTheme.color.text.primary
     )
@@ -117,8 +118,7 @@ internal fun CaramelBottomTodoScope.TodoTitle(
 internal fun CaramelBottomTodoScope.TodoDescription(
     modifier: Modifier = Modifier
 ) {
-    val descriptionText = this.description ?: return
-
+    val descriptionText = this.description.ifEmpty { return }
     Text(
         modifier = modifier
             .fillMaxWidth()

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/component/calendar/Schedule.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/component/calendar/Schedule.kt
@@ -173,7 +173,7 @@ private fun CalendarTodoItem(
             ),
         maxLines = 1,
         overflow = TextOverflow.Clip,
-        text = todo.title,
+        text = todo.title.ifEmpty { todo.description },
         style = CaramelTheme.typography.label3.bold,
         color = CaramelTheme.color.text.labelBrand
     )


### PR DESCRIPTION
## 작업한 내용
- URL은 제목 + 내용에 존재하는 내용 중 첫번째 URL로 설정
- 캘린더 셀의 아이템은 제목 or 본문 중 비어있지 않은 값으로 설정
- 캘린더 바텀시트의 아이템은 제목 or 본문 중 비어있지 않은 값으로 설정

![image](https://github.com/user-attachments/assets/423eb4bd-cf89-4b03-8981-07b142e31287)
