### PR TITLE
[QA] 커플 만난일에 대한 계산에 +1 추가

### DIFF
--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Couple.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Couple.kt
@@ -19,7 +19,7 @@ data class Couple(
                 val (year, month, day) = startDate.split(".").map{ it.toInt() }
                 val startDate = LocalDate(year, month, day)
                 val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
-                return startDate.daysUntil(today)
+                return startDate.daysUntil(today) + 1
             } catch (e: Exception) {
                 return 0
             }


### PR DESCRIPTION
## 관련 이슈
- [커플 기념일 - 시작일을 오늘로 설정하면 발생](https://www.notion.so/given-dragon/205870f222b9802ebc97da0c4ad18f77)

## 작업한 내용
- 커플 엔티티의 `daysTogether`에 +1을 추가