### PR TITLE
[QA] 컨텐츠 상세 - 날짜, 시간 UI 추가

### DIFF
--- a/feature/content/detail/src/androidMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailPreview.kt
+++ b/feature/content/detail/src/androidMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailPreview.kt
@@ -1,0 +1,33 @@
+package com.whatever.caramel.feature.content.detail
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.core.domain.vo.calendar.ScheduleDetail
+import com.whatever.caramel.core.domain.vo.content.ContentType
+import com.whatever.caramel.feature.content.detail.mvi.ContentDetailState
+
+@Composable
+@Preview
+private fun ContentDetailScreenPreview() {
+    CaramelTheme {
+        ContentDetailScreen(
+            state = ContentDetailState(
+                contentType = ContentType.CALENDAR,
+                scheduleDetail = ScheduleDetail(
+                    scheduleId = 0L,
+                    startDateTime = "2025-07-01T10:05:17",
+                    endDateTime = "qwdasd",
+                    startDateTimezone = "timezone",
+                    endDateTimezone = "TODO()",
+                    isCompleted = true,
+                    parentScheduleId = 0L,
+                    title = "test",
+                    description = "asdasdsa",
+                    tags = emptyList()
+                )
+            ),
+            onIntent = {}
+        )
+    }
+}

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailScreen.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -86,6 +87,33 @@ internal fun ContentDetailScreen(
                     onKeyboardAction = {},
                     readOnly = true,
                 )
+                if (state.scheduleDetail != null) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = CaramelTheme.spacing.xl)
+                            .padding(horizontal = CaramelTheme.spacing.xl),
+                        horizontalArrangement = Arrangement.spacedBy(
+                            space = CaramelTheme.spacing.s,
+                            alignment = Alignment.Start
+                        )
+                    ) {
+                        Icon(
+                            painter = painterResource(resource = Resources.Icon.ic_calendar_24),
+                            contentDescription = null
+                        )
+                        Text(
+                            text = state.date,
+                            style = CaramelTheme.typography.body2.regular,
+                            color = CaramelTheme.color.text.primary
+                        )
+                        Text(
+                            text = state.time,
+                            style = CaramelTheme.typography.body2.regular,
+                            color = CaramelTheme.color.text.primary
+                        )
+                    }
+                }
                 HorizontalDivider(
                     modifier = Modifier.padding(vertical = CaramelTheme.spacing.xl),
                     color = CaramelTheme.color.divider.primary

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/mvi/ContentDetailState.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/mvi/ContentDetailState.kt
@@ -9,6 +9,8 @@ import com.whatever.caramel.core.viewmodel.UiState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.format.DateTimeFormat
 
 data class ContentDetailState(
     val contentId: Long = -1L,
@@ -38,5 +40,23 @@ data class ContentDetailState(
         get() = when (contentType) {
             ContentType.MEMO -> memoDetail?.tagList?.toImmutableList() ?: persistentListOf()
             ContentType.CALENDAR -> scheduleDetail?.tags?.toImmutableList() ?: persistentListOf()
+        }
+
+    val date: String
+        get() {
+            val dateTime = scheduleDetail?.startDateTime ?: ""
+            val parsed = LocalDateTime.parse(dateTime)
+
+            return  "${parsed.year}년 ${parsed.monthNumber}월 ${parsed.dayOfMonth}일"
+        }
+
+    val time: String
+        get() {
+            val dateTime = scheduleDetail?.startDateTime ?: ""
+            val parsed = LocalDateTime.parse(dateTime)
+            val hour = parsed.hour.toString().padStart(2, '0')
+            val minute = parsed.minute.toString().padStart(2, '0')
+
+            return  "$hour:$minute"
         }
 } 


### PR DESCRIPTION
## 작업한 내용
- 컨텐츠 상세의 모드가 스케쥴일 경우, 날짜와 시간 UI를 추가

![image](https://github.com/user-attachments/assets/609bf070-73b0-49c5-a978-516f3883d3c6)
