### PR TITLE
[Feat] Pre-Commit Hook 코드 포맷팅 자동화 구현

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: spotless-apply
+        name: Run Spotless Apply
+        entry: ./gradlew spotlessApply
+        language: system
+        always_run: true
+        pass_filenames: false


### PR DESCRIPTION
## 작업한 내용
- Pre-Commit Hook로 코드 포맷팅 자동화

## PR 포인트
- 동작 과정
  - local에서 커밋 이전에 설정된 Hook이 실행됩니다.
  - 커밋 되기전 spotlessApply로 코드를 포맷팅 하여 실패시 커밋 중단과 자동 포맷팅을 성공시 커밋을 진행합니다.
- Pre-Commit Hook 설정 방법
```bash
# 1. macOS pre-commit 설치
brew install pre-commit
# or WindowOS pre-commit 설치
pip install pre-commit

# 2. 프로젝트의 pre-commit 연결
pre-commit install 

# 3. 설치 적용 확인
pre-commit run --all-files
``` 
- Pre-Commit 해제 방법
```bash
pre-commit uninstall
```