### PR TITLE
[QA] 회원탈퇴 후 토큰을 삭제하도록 변경

### DIFF
--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/auth/SignOutUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/usecase/auth/SignOutUseCase.kt
@@ -11,6 +11,7 @@ class SignOutUseCase(
 ) {
     suspend operator fun invoke() {
         authRepository.signOut()
+        authRepository.deleteToken()
         userRepository.deleteUserStatus()
         coupleRepository.deleteCoupleId()
     }


### PR DESCRIPTION
## 관련 이슈
- [회원탈퇴 시 토큰 삭제](https://www.notion.so/given-dragon/8083036713414226b266dd26bbdb7106?v=47daa3ead13148f588277f7bbf69bc66&p=21c870f222b98070bf52e32977277273&pm=s)

## 작업한 내용
- `SignOutUseCase`에서 토큰 삭제 추가

## PR 포인트
- 회원탈퇴 후 앱 종료 -> 앱 재실행을 하면 기존에 남아있는 토큰으로 갱신요청을 보내고 있었습니다.
- 동작 상 큰 문제는 없지만 서버 로그 확인 시 정확한 로그를 확인하기 어려워 토큰을 삭제했습니다.