### PR TITLE
[QA] 메인 - 홈, 캘린더, 메모 화면 시스템 statusbar 컬러 적용

### DIFF
--- a/app-ios/iosApp/AppDelegate.swift
+++ b/app-ios/iosApp/AppDelegate.swift
@@ -137,7 +137,7 @@ extension AppDelegate: DeepLinkDelegate {
             
             deepLinkHandler.handleAppsFlyerDataRaw(
                 deepLinkValue: deeplinkValue,
-                rawParams: rawParams as [String : Any]
+                rawParams: rawParams
             )
         }
     }

--- a/app-ios/iosApp/AppDelegate.swift
+++ b/app-ios/iosApp/AppDelegate.swift
@@ -137,7 +137,7 @@ extension AppDelegate: DeepLinkDelegate {
             
             deepLinkHandler.handleAppsFlyerDataRaw(
                 deepLinkValue: deeplinkValue,
-                rawParams: rawParams
+                rawParams: rawParams as [String : Any]
             )
         }
     }

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarScreen.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -124,7 +125,10 @@ internal fun CalendarScreen(
     }
 
     PullToRefreshBox(
-        modifier = Modifier.background(color = CaramelTheme.color.background.primary),
+        modifier =
+            Modifier
+                .background(color = CaramelTheme.color.background.primary)
+                .statusBarsPadding(),
         state = pullToRefreshState,
         isRefreshing = state.isRefreshing,
         onRefresh = { onIntent(CalendarIntent.RefreshCalendar) },

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -80,6 +81,7 @@ internal fun HomeScreen(
         containerColor = CaramelTheme.color.background.primary,
         topBar = {
             CaramelTopBar(
+                modifier = Modifier.statusBarsPadding(),
                 trailingIcon = {
                     Icon(
                         modifier =

--- a/feature/main/src/commonMain/kotlin/com/whatever/caramel/feature/main/MainRoute.kt
+++ b/feature/main/src/commonMain/kotlin/com/whatever/caramel/feature/main/MainRoute.kt
@@ -108,7 +108,9 @@ internal fun MainRoute(
         },
     ) { innerPadding ->
         NavHost(
-            modifier = Modifier.padding(paddingValues = innerPadding),
+            modifier =
+                Modifier
+                    .padding(bottom = innerPadding.calculateBottomPadding()),
             navController = mainNavHostController,
             startDestination = HomeRoute,
             enterTransition = { EnterTransition.None },

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoScreen.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
@@ -77,7 +78,10 @@ internal fun MemoScreen(
     }
 
     PullToRefreshBox(
-        modifier = Modifier.background(color = CaramelTheme.color.background.primary),
+        modifier =
+            Modifier
+                .background(color = CaramelTheme.color.background.primary)
+                .statusBarsPadding(),
         state = pullToRefreshState,
         isRefreshing = state.isRefreshing,
         onRefresh = { onIntent(MemoIntent.PullToRefresh) },


### PR DESCRIPTION
# 관련 이슈
- [Statusbar 컬러 이슈](https://www.notion.so/given-dragon/8083036713414226b266dd26bbdb7106?v=47daa3ead13148f588277f7bbf69bc66&p=221870f222b980b79813c7ddc1b335d7&pm=s)

## 작업한 내용
- 메인 화면 3개의 탭에서 디자인과 같게 statusbar 컬러 적용

<img src="https://github.com/user-attachments/assets/5df39e28-3f10-45be-aaaa-dfcac8605be1" width=250/>
<img src="https://github.com/user-attachments/assets/24d01ba3-0f30-4353-ade2-ce6c15f2e74c" width=250/>
<img src="https://github.com/user-attachments/assets/d3ad2ae3-ab94-4826-91d3-8a05393ba66f" width=250/>

<img src="https://github.com/user-attachments/assets/9b22e0e0-1a81-4384-a2b0-41cfa37dc600" width=250/>
<img src="https://github.com/user-attachments/assets/bbc00435-aec5-4fdb-95de-937f58ebd591" width=250/>
<img src="https://github.com/user-attachments/assets/0d66799b-f525-40f4-96d9-07734f139743" width=250/>

