### PR TITLE
[Feat] Crashlytics 로깅 범위 확장

### DIFF
--- a/app-ios/firebaseCrashlyticsBridge/FirebaseCrashlyticsBridge.swift
+++ b/app-ios/firebaseCrashlyticsBridge/FirebaseCrashlyticsBridge.swift
@@ -11,9 +11,9 @@ import FirebaseCrashlytics
         Crashlytics.crashlytics().log(message)
     }
 
-    public func recordException(errorTrace : String) {
+    public func recordException(errorClassName : String, errorTrace : String) {
         let error = NSError(
-            domain : "KotlinException",
+            domain : errorClassName,
             code : 0,
             userInfo: [NSLocalizedDescriptionKey : errorTrace]
         )

--- a/app-ios/iosApp/AppDelegate.swift
+++ b/app-ios/iosApp/AppDelegate.swift
@@ -29,6 +29,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+#if DEBUG
+        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(false)
+#endif
         FirebaseApp.configure()
         CaramelAnalytics_iosKt.firebaseCallback(callback: FirebaseLoggingCallback())
         

--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelViewModel.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelViewModel.kt
@@ -2,6 +2,7 @@ package com.whatever.caramel.app
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.deeplink.DeepLinkHandler
 import com.whatever.caramel.core.deeplink.model.AppsFlyerDeepLinkValue
 import com.whatever.caramel.core.deeplink.model.CaramelDeepLink
@@ -10,6 +11,7 @@ import com.whatever.caramel.core.domain.exception.code.CoupleErrorCode
 import com.whatever.caramel.core.domain.usecase.couple.ConnectCoupleUseCase
 import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.core.viewmodel.BaseViewModel
+import com.whatever.caramel.feature.calendar.mvi.CalendarSideEffect
 import com.whatever.caramel.mvi.AppIntent
 import com.whatever.caramel.mvi.AppSideEffect
 import com.whatever.caramel.mvi.AppState
@@ -19,7 +21,8 @@ class CaramelViewModel(
     private val connectCoupleUseCase: ConnectCoupleUseCase,
     private val deepLinkHandler: DeepLinkHandler,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<AppState, AppSideEffect, AppIntent>(savedStateHandle) {
+    crashlytics: CaramelCrashlytics,
+) : BaseViewModel<AppState, AppSideEffect, AppIntent>(savedStateHandle, crashlytics) {
     init {
         viewModelScope.launch {
             deepLinkHandler.deepLinkFlow.collect { deepLink ->
@@ -39,22 +42,23 @@ class CaramelViewModel(
 
     override fun handleClientException(throwable: Throwable) {
         super.handleClientException(throwable)
-
-        val exception = throwable as CaramelException
-
-        when (exception.code) {
-            CoupleErrorCode.INVITATION_CODE_EXPIRED -> {
-                reduce {
-                    copy(
-                        isShowErrorDialog = true,
-                        dialogMessage = exception.message,
-                    )
+        if(throwable is CaramelException) {
+            when (throwable.code) {
+                CoupleErrorCode.INVITATION_CODE_EXPIRED -> {
+                    reduce {
+                        copy(
+                            isShowErrorDialog = true,
+                            dialogMessage = throwable.message,
+                        )
+                    }
                 }
+                // @ham2174 TODO : 커플 연결 실패시 현재 상태를 나타내는 안내 필요
+                // ex) UserStatus == NONE 일 때 Token이 없기 때문에 로그인을 하라는 예외 메세지 받기
+                // ex) UserStatus == NEW 일 때 프로필을 생성해달라는 예외 메세지 받기
+                // ex) UserStatus == COUPLED 일 때 커플 상태이므로 연결이 불가능하다는 예외 메세지 받기
             }
-            // @ham2174 TODO : 커플 연결 실패시 현재 상태를 나타내는 안내 필요
-            // ex) UserStatus == NONE 일 때 Token이 없기 때문에 로그인을 하라는 예외 메세지 받기
-            // ex) UserStatus == NEW 일 때 프로필을 생성해달라는 예외 메세지 받기
-            // ex) UserStatus == COUPLED 일 때 커플 상태이므로 연결이 불가능하다는 예외 메세지 받기
+        } else {
+            caramelCrashlytics.recordException(throwable)
         }
     }
 

--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelViewModel.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelViewModel.kt
@@ -11,7 +11,6 @@ import com.whatever.caramel.core.domain.exception.code.CoupleErrorCode
 import com.whatever.caramel.core.domain.usecase.couple.ConnectCoupleUseCase
 import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.core.viewmodel.BaseViewModel
-import com.whatever.caramel.feature.calendar.mvi.CalendarSideEffect
 import com.whatever.caramel.mvi.AppIntent
 import com.whatever.caramel.mvi.AppSideEffect
 import com.whatever.caramel.mvi.AppState
@@ -42,7 +41,7 @@ class CaramelViewModel(
 
     override fun handleClientException(throwable: Throwable) {
         super.handleClientException(throwable)
-        if(throwable is CaramelException) {
+        if (throwable is CaramelException) {
             when (throwable.code) {
                 CoupleErrorCode.INVITATION_CODE_EXPIRED -> {
                     reduce {

--- a/app/src/iosMain/kotlin/com/whatever/caramel/di/Module.ios.kt
+++ b/app/src/iosMain/kotlin/com/whatever/caramel/di/Module.ios.kt
@@ -14,6 +14,7 @@ actual val appViewModelModule: Module
                     connectCoupleUseCase = get(),
                     deepLinkHandler = get(),
                     savedStateHandle = SavedStateHandle(),
+                    crashlytics = get()
                 /*
                  @ham2174 FIXME : SavedStateHandle Ios에서 사용 불가능.
                  koin-compose-viewmodel 버전이 업데이트 되기 전까지 CaramelViewModel 의 SavedStateHandle 사용 불가

--- a/app/src/iosMain/kotlin/com/whatever/caramel/di/Module.ios.kt
+++ b/app/src/iosMain/kotlin/com/whatever/caramel/di/Module.ios.kt
@@ -14,7 +14,7 @@ actual val appViewModelModule: Module
                     connectCoupleUseCase = get(),
                     deepLinkHandler = get(),
                     savedStateHandle = SavedStateHandle(),
-                    crashlytics = get()
+                    crashlytics = get(),
                 /*
                  @ham2174 FIXME : SavedStateHandle Ios에서 사용 불가능.
                  koin-compose-viewmodel 버전이 업데이트 되기 전까지 CaramelViewModel 의 SavedStateHandle 사용 불가

--- a/core/crashlytics/build.gradle.kts
+++ b/core/crashlytics/build.gradle.kts
@@ -8,9 +8,18 @@ plugins {
     alias(libs.plugins.kmp.spm)
 }
 
-android.namespace = "com.whatever.caramel.core.crashlytics"
+android {
+    namespace = "com.whatever.caramel.core.crashlytics"
+    buildFeatures {
+        buildConfig = true
+    }
+}
 
 kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xexpect-actual-classes")
+    }
+
     val isWindow = System.getProperty("os.name").lowercase(Locale.getDefault()).contains("windows")
 
     if (!isWindow) {

--- a/core/crashlytics/build.gradle.kts
+++ b/core/crashlytics/build.gradle.kts
@@ -16,10 +16,6 @@ android {
 }
 
 kotlin {
-    compilerOptions {
-        freeCompilerArgs.add("-Xexpect-actual-classes")
-    }
-
     val isWindow = System.getProperty("os.name").lowercase(Locale.getDefault()).contains("windows")
 
     if (!isWindow) {

--- a/core/crashlytics/src/androidMain/kotlin/com/whatever/caramel/core/crashlytics/CaramelCrashlyticsImpl.kt
+++ b/core/crashlytics/src/androidMain/kotlin/com/whatever/caramel/core/crashlytics/CaramelCrashlyticsImpl.kt
@@ -3,7 +3,9 @@ package com.whatever.caramel.core.crashlytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 
 class CaramelCrashlyticsImpl : CaramelCrashlytics {
-    private val crashlytics = FirebaseCrashlytics.getInstance()
+    private val crashlytics = FirebaseCrashlytics.getInstance().apply {
+        isCrashlyticsCollectionEnabled = !BuildConfig.DEBUG
+    }
 
     override fun log(message: String) {
         crashlytics.log(message)

--- a/core/crashlytics/src/androidMain/kotlin/com/whatever/caramel/core/crashlytics/CaramelCrashlyticsImpl.kt
+++ b/core/crashlytics/src/androidMain/kotlin/com/whatever/caramel/core/crashlytics/CaramelCrashlyticsImpl.kt
@@ -3,9 +3,10 @@ package com.whatever.caramel.core.crashlytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 
 class CaramelCrashlyticsImpl : CaramelCrashlytics {
-    private val crashlytics = FirebaseCrashlytics.getInstance().apply {
-        isCrashlyticsCollectionEnabled = !BuildConfig.DEBUG
-    }
+    private val crashlytics =
+        FirebaseCrashlytics.getInstance().apply {
+            isCrashlyticsCollectionEnabled = !BuildConfig.DEBUG
+        }
 
     override fun log(message: String) {
         crashlytics.log(message)

--- a/core/crashlytics/src/iosMain/kotlin/com/whatever/caramel/core/crashlytics/CaramelCrashlyticsImpl.kt
+++ b/core/crashlytics/src/iosMain/kotlin/com/whatever/caramel/core/crashlytics/CaramelCrashlyticsImpl.kt
@@ -17,7 +17,8 @@ class CaramelCrashlyticsImpl(
                 appendLine(throwable.toString())
                 throwable.stackTraceToString().lines().forEach { appendLine(it) }
             }
-        firebaseCrashlytics.recordExceptionWithErrorTrace(errorTrace = errorInfo)
+        val errorClassName = throwable::class.simpleName ?: "UnknownException"
+        firebaseCrashlytics.recordExceptionWithErrorClassName(errorClassName = errorClassName, errorTrace = errorInfo)
     }
 
     override fun setKey(

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -20,7 +20,6 @@ kotlin {
             implementation(projects.core.remote)
 
             implementation(projects.core.util)
-            implementation(projects.core.crashlytics)
 
             implementation(libs.koin.core)
 

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/util/SafeCall.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/util/SafeCall.kt
@@ -15,39 +15,22 @@ import org.koin.core.component.get
 suspend fun <T> safeCall(block: suspend () -> T): T =
     try {
         block.invoke()
+    } catch (e: CaramelNetworkException) {
+        throw e.toCaramelException()
+    } catch (e: IOException) {
+        throw CaramelException(
+            code = NetworkErrorCode.UNKNOWN,
+            message = "네트워크 오류가 발생했습니다.",
+            debugMessage = e.message,
+            errorUiType = ErrorUiType.DIALOG,
+        )
+    } catch (e: TimeoutCancellationException) {
+        throw CaramelException(
+            code = NetworkErrorCode.UNKNOWN,
+            message = "네트워크 요청이 시간 초과되었습니다.",
+            debugMessage = e.message,
+            errorUiType = ErrorUiType.DIALOG,
+        )
     } catch (e: Exception) {
-        throw e.toCaramelExceptionWithReporting()
-    }
-
-private fun Throwable.toCaramelExceptionWithReporting(
-    caramelCrashlytics: CaramelCrashlytics = object : KoinComponent {}.get(),
-): CaramelException =
-    when (this) {
-        is CaramelNetworkException -> this.toCaramelException()
-        is IOException ->
-            CaramelException(
-                code = NetworkErrorCode.UNKNOWN,
-                message = "네트워크 오류가 발생했습니다.",
-                debugMessage = message,
-                errorUiType = ErrorUiType.DIALOG,
-            )
-        is TimeoutCancellationException ->
-            CaramelException(
-                code = NetworkErrorCode.UNKNOWN,
-                message = "네트워크 요청이 시간 초과되었습니다.",
-                debugMessage = message,
-                errorUiType = ErrorUiType.DIALOG,
-            )
-        else -> {
-            caramelCrashlytics.run {
-                log("Repository 호출중 예상치 못한 오류 발생")
-                recordException(this@toCaramelExceptionWithReporting)
-            }
-            CaramelException(
-                code = NetworkErrorCode.UNKNOWN,
-                message = "예상치 못한 에러가 발생했습니다.",
-                debugMessage = message,
-                errorUiType = ErrorUiType.DIALOG,
-            )
-        }
+        throw e
     }

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/util/SafeCall.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/util/SafeCall.kt
@@ -1,6 +1,5 @@
 package com.whatever.caramel.core.data.util
 
-import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.data.mapper.toCaramelException
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
@@ -8,7 +7,6 @@ import com.whatever.caramel.core.domain.exception.code.NetworkErrorCode
 import com.whatever.caramel.core.remote.network.exception.CaramelNetworkException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.io.IOException
-import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 
 // @ham2174 TODO : 로컬 관련 커스텀 예외 추가시 catch 추가

--- a/core/viewmodel/build.gradle.kts
+++ b/core/viewmodel/build.gradle.kts
@@ -9,6 +9,7 @@ android.namespace = "com.whatever.caramel.core.viewmodel"
 kotlin {
     sourceSets {
         commonMain.dependencies {
+            implementation(projects.core.crashlytics)
             implementation(libs.androidx.lifecycle.viewmodel)
             implementation(libs.androidx.lifecycle.viewmodel.savestate)
         }

--- a/core/viewmodel/src/commonMain/kotlin/com/whatever/caramel/core/viewmodel/BaseViewModel.kt
+++ b/core/viewmodel/src/commonMain/kotlin/com/whatever/caramel/core/viewmodel/BaseViewModel.kt
@@ -3,6 +3,7 @@ package com.whatever.caramel.core.viewmodel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -18,9 +19,9 @@ import kotlin.coroutines.EmptyCoroutineContext
 
 abstract class BaseViewModel<S : UiState, SE : UiSideEffect, I : UiIntent>(
     val savedStateHandle: SavedStateHandle,
+    protected val caramelCrashlytics : CaramelCrashlytics
 ) : ViewModel() {
     private val initialState: S by lazy { createInitialState(savedStateHandle) }
-
     protected abstract fun createInitialState(savedStateHandle: SavedStateHandle): S
 
     protected abstract suspend fun handleIntent(intent: I)
@@ -41,6 +42,7 @@ abstract class BaseViewModel<S : UiState, SE : UiSideEffect, I : UiIntent>(
 
     fun intent(intent: I) {
         launch {
+            caramelCrashlytics.log("${this@BaseViewModel::class.simpleName} > received intent : $intent")
             handleIntent(intent)
         }
     }

--- a/core/viewmodel/src/commonMain/kotlin/com/whatever/caramel/core/viewmodel/BaseViewModel.kt
+++ b/core/viewmodel/src/commonMain/kotlin/com/whatever/caramel/core/viewmodel/BaseViewModel.kt
@@ -19,9 +19,10 @@ import kotlin.coroutines.EmptyCoroutineContext
 
 abstract class BaseViewModel<S : UiState, SE : UiSideEffect, I : UiIntent>(
     val savedStateHandle: SavedStateHandle,
-    protected val caramelCrashlytics : CaramelCrashlytics
+    protected val caramelCrashlytics: CaramelCrashlytics,
 ) : ViewModel() {
     private val initialState: S by lazy { createInitialState(savedStateHandle) }
+
     protected abstract fun createInitialState(savedStateHandle: SavedStateHandle): S
 
     protected abstract suspend fun handleIntent(intent: I)

--- a/feature/calendar/build.gradle.kts
+++ b/feature/calendar/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
             implementation(projects.core.util)
 

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarViewModel.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarViewModel.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.calendar
 
 import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
 import com.whatever.caramel.core.domain.usecase.calendar.GetHolidaysUseCase
@@ -29,8 +30,9 @@ class CalendarViewModel(
     private val getTodosGroupByStartDateUseCase: GetTodosGroupByStartDateUseCase,
     private val getHolidaysUseCase: GetHolidaysUseCase,
     private val getAnniversariesUseCase: GetAnniversariesUseCase,
+    crashlytics : CaramelCrashlytics,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<CalendarState, CalendarSideEffect, CalendarIntent>(savedStateHandle) {
+) : BaseViewModel<CalendarState, CalendarSideEffect, CalendarIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): CalendarState {
         val currentDate = DateUtil.today()
         return CalendarState(
@@ -64,9 +66,11 @@ class CalendarViewModel(
                     )
             }
         } else {
+            caramelCrashlytics.recordException(throwable)
             postSideEffect(
-                CalendarSideEffect.ShowErrorToast(
-                    message = throwable.message ?: "알 수 없는 오류가 발생했습니다.",
+                CalendarSideEffect.ShowErrorDialog(
+                    message = "알 수 없는 오류가 발생했습니다.",
+                    description = null
                 ),
             )
         }

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarViewModel.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarViewModel.kt
@@ -30,7 +30,7 @@ class CalendarViewModel(
     private val getTodosGroupByStartDateUseCase: GetTodosGroupByStartDateUseCase,
     private val getHolidaysUseCase: GetHolidaysUseCase,
     private val getAnniversariesUseCase: GetAnniversariesUseCase,
-    crashlytics : CaramelCrashlytics,
+    crashlytics: CaramelCrashlytics,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<CalendarState, CalendarSideEffect, CalendarIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): CalendarState {
@@ -70,7 +70,7 @@ class CalendarViewModel(
             postSideEffect(
                 CalendarSideEffect.ShowErrorDialog(
                     message = "알 수 없는 오류가 발생했습니다.",
-                    description = null
+                    description = null,
                 ),
             )
         }

--- a/feature/content/create/build.gradle.kts
+++ b/feature/content/create/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.util)
             implementation(projects.core.viewmodel)
 

--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
@@ -84,7 +84,7 @@ class ContentCreateViewModel(
             postSideEffect(
                 ContentCreateSideEffect.ShowErrorDialog(
                     message = "알 수 없는 오류가 발생했습니다.",
-                    description = null
+                    description = null,
                 ),
             )
         }

--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
@@ -2,6 +2,7 @@ package com.whatever.caramel.feature.content.create
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
 import com.whatever.caramel.core.domain.usecase.memo.CreateContentUseCase
@@ -26,10 +27,11 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
 class ContentCreateViewModel(
+    crashlytics: CaramelCrashlytics,
     savedStateHandle: SavedStateHandle,
     private val getTagUseCase: GetTagUseCase,
     private val createContentUseCase: CreateContentUseCase,
-) : BaseViewModel<ContentCreateState, ContentCreateSideEffect, ContentCreateIntent>(savedStateHandle) {
+) : BaseViewModel<ContentCreateState, ContentCreateSideEffect, ContentCreateIntent>(savedStateHandle, crashlytics) {
     init {
         launch {
             val tags = getTagUseCase()
@@ -78,9 +80,11 @@ class ContentCreateViewModel(
                     )
             }
         } else {
+            caramelCrashlytics.recordException(throwable)
             postSideEffect(
-                ContentCreateSideEffect.ShowToast(
-                    message = throwable.message ?: "알 수 없는 오류가 발생했습니다.",
+                ContentCreateSideEffect.ShowErrorDialog(
+                    message = "알 수 없는 오류가 발생했습니다.",
+                    description = null
                 ),
             )
         }

--- a/feature/content/detail/build.gradle.kts
+++ b/feature/content/detail/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
 
             implementation(libs.koin.core)

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailViewModel.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailViewModel.kt
@@ -2,6 +2,7 @@ package com.whatever.caramel.feature.content.detail
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
 import com.whatever.caramel.core.domain.exception.code.ContentErrorCode
@@ -23,12 +24,13 @@ import kotlinx.coroutines.flow.onStart
 
 class ContentDetailViewModel(
     savedStateHandle: SavedStateHandle,
+    crashlytics : CaramelCrashlytics,
     private val getMemoUseCase: GetMemoUseCase,
     private val getScheduleUseCase: GetScheduleUseCase,
     private val deleteMemoUseCase: DeleteMemoUseCase,
     private val deleteScheduleUseCase: DeleteScheduleUseCase,
     private val getLinkPreviewsForContentUseCase: GetLinkPreviewsForContentUseCase,
-) : BaseViewModel<ContentDetailState, ContentDetailSideEffect, ContentDetailIntent>(savedStateHandle) {
+) : BaseViewModel<ContentDetailState, ContentDetailSideEffect, ContentDetailIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): ContentDetailState {
         val arguments = savedStateHandle.toRoute<ContentDetailRoute>()
         return ContentDetailState(
@@ -80,9 +82,11 @@ class ContentDetailViewModel(
                 }
             }
         } else {
+            caramelCrashlytics.recordException(throwable)
             postSideEffect(
-                ContentDetailSideEffect.ShowErrorSnackBar(
-                    message = throwable.message ?: "알 수 없는 오류가 발생했습니다.",
+                ContentDetailSideEffect.ShowErrorDialog(
+                    message = "알 수 없는 오류가 발생했습니다.",
+                    description = null
                 ),
             )
         }

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailViewModel.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailViewModel.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.onStart
 
 class ContentDetailViewModel(
     savedStateHandle: SavedStateHandle,
-    crashlytics : CaramelCrashlytics,
+    crashlytics: CaramelCrashlytics,
     private val getMemoUseCase: GetMemoUseCase,
     private val getScheduleUseCase: GetScheduleUseCase,
     private val deleteMemoUseCase: DeleteMemoUseCase,
@@ -86,7 +86,7 @@ class ContentDetailViewModel(
             postSideEffect(
                 ContentDetailSideEffect.ShowErrorDialog(
                     message = "알 수 없는 오류가 발생했습니다.",
-                    description = null
+                    description = null,
                 ),
             )
         }

--- a/feature/content/edit/build.gradle.kts
+++ b/feature/content/edit/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
             implementation(projects.core.util)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
 
             implementation(libs.koin.core)

--- a/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditViewModel.kt
+++ b/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditViewModel.kt
@@ -41,9 +41,9 @@ class ContentEditViewModel(
     private val updateScheduleUseCase: UpdateScheduleUseCase,
     private val deleteScheduleUseCase: DeleteScheduleUseCase,
 ) : BaseViewModel<ContentEditState, ContentEditSideEffect, ContentEditIntent>(
-    savedStateHandle = savedStateHandle,
-    caramelCrashlytics = crashlytics
-) {
+        savedStateHandle = savedStateHandle,
+        caramelCrashlytics = crashlytics,
+    ) {
     init {
         loadContent()
         loadTags()
@@ -89,7 +89,7 @@ class ContentEditViewModel(
             postSideEffect(
                 ContentEditSideEffect.ShowErrorDialog(
                     message = "알 수 없는 오류가 발생했습니다.",
-                    description = null
+                    description = null,
                 ),
             )
         }

--- a/feature/couple/connect/build.gradle.kts
+++ b/feature/couple/connect/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
 
             implementation(libs.koin.core)

--- a/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectViewModel.kt
+++ b/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectViewModel.kt
@@ -48,7 +48,7 @@ class CoupleConnectViewModel(
             postSideEffect(
                 CoupleConnectSideEffect.ShowErrorDialog(
                     message = "알 수 없는 오류가 발생했습니다.",
-                    description = null
+                    description = null,
                 ),
             )
         }

--- a/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectViewModel.kt
+++ b/feature/couple/connect/src/commonMain/kotlin/com/whatever/caramel/feature/couple/connect/CoupleConnectViewModel.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.couple.connect
 
 import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
 import com.whatever.caramel.core.domain.usecase.couple.ConnectCoupleUseCase
@@ -12,7 +13,8 @@ import com.whatever.caramel.feature.couple.connect.mvi.CoupleConnectState
 class CoupleConnectViewModel(
     private val connectCoupleUseCase: ConnectCoupleUseCase,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<CoupleConnectState, CoupleConnectSideEffect, CoupleConnectIntent>(savedStateHandle) {
+    crashlytics: CaramelCrashlytics,
+) : BaseViewModel<CoupleConnectState, CoupleConnectSideEffect, CoupleConnectIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): CoupleConnectState = CoupleConnectState()
 
     override suspend fun handleIntent(intent: CoupleConnectIntent) {
@@ -42,9 +44,11 @@ class CoupleConnectViewModel(
                     )
             }
         } else {
+            caramelCrashlytics.recordException(throwable)
             postSideEffect(
-                CoupleConnectSideEffect.ShowErrorToast(
-                    message = throwable.message ?: "알 수 없는 오류가 발생했습니다.",
+                CoupleConnectSideEffect.ShowErrorDialog(
+                    message = "알 수 없는 오류가 발생했습니다.",
+                    description = null
                 ),
             )
         }

--- a/feature/couple/connecting/build.gradle.kts
+++ b/feature/couple/connecting/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
 
             implementation(libs.koin.core)

--- a/feature/couple/connecting/src/commonMain/kotlin/com/whatever/caramel/feature/copule/connecting/CoupleConnectingViewModel.kt
+++ b/feature/couple/connecting/src/commonMain/kotlin/com/whatever/caramel/feature/copule/connecting/CoupleConnectingViewModel.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.copule.connecting
 
 import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.viewmodel.BaseViewModel
 import com.whatever.caramel.feature.copule.connecting.mvi.CoupleConnectingIntent
 import com.whatever.caramel.feature.copule.connecting.mvi.CoupleConnectingSideEffect
@@ -9,7 +10,8 @@ import kotlinx.coroutines.delay
 
 class CoupleConnectingViewModel(
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<CoupleConnectingState, CoupleConnectingSideEffect, CoupleConnectingIntent>(savedStateHandle) {
+    crashlytics: CaramelCrashlytics,
+) : BaseViewModel<CoupleConnectingState, CoupleConnectingSideEffect, CoupleConnectingIntent>(savedStateHandle, crashlytics) {
     init {
         launch {
             delay(2000L)

--- a/feature/couple/invite/build.gradle.kts
+++ b/feature/couple/invite/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
 
             implementation(libs.koin.core)

--- a/feature/couple/invite/src/commonMain/kotlin/com/whatever/caramel/feature/copule/invite/CoupleInviteViewModel.kt
+++ b/feature/couple/invite/src/commonMain/kotlin/com/whatever/caramel/feature/copule/invite/CoupleInviteViewModel.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.copule.invite
 
 import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
 import com.whatever.caramel.core.domain.repository.CoupleRepository
@@ -12,7 +13,8 @@ import com.whatever.caramel.feature.copule.invite.mvi.CoupleInviteState
 class CoupleInviteViewModel(
     private val coupleRepository: CoupleRepository,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<CoupleInviteState, CoupleInviteSideEffect, CoupleInviteIntent>(savedStateHandle) {
+    crashlytics: CaramelCrashlytics,
+) : BaseViewModel<CoupleInviteState, CoupleInviteSideEffect, CoupleInviteIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): CoupleInviteState = CoupleInviteState()
 
     override suspend fun handleIntent(intent: CoupleInviteIntent) {
@@ -43,9 +45,11 @@ class CoupleInviteViewModel(
                     )
             }
         } else {
+            caramelCrashlytics.recordException(throwable)
             postSideEffect(
-                CoupleInviteSideEffect.ShowErrorToast(
-                    message = throwable.message ?: "알 수 없는 오류가 발생했습니다.",
+                CoupleInviteSideEffect.ShowErrorDialog(
+                    message = "알 수 없는 오류가 발생했습니다.",
+                    description = null
                 ),
             )
         }

--- a/feature/couple/invite/src/commonMain/kotlin/com/whatever/caramel/feature/copule/invite/CoupleInviteViewModel.kt
+++ b/feature/couple/invite/src/commonMain/kotlin/com/whatever/caramel/feature/copule/invite/CoupleInviteViewModel.kt
@@ -49,7 +49,7 @@ class CoupleInviteViewModel(
             postSideEffect(
                 CoupleInviteSideEffect.ShowErrorDialog(
                     message = "알 수 없는 오류가 발생했습니다.",
-                    description = null
+                    description = null,
                 ),
             )
         }

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
             implementation(projects.core.util)
 

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
@@ -29,7 +29,7 @@ class HomeViewModel(
     private val getTodayBalanceGameUseCase: GetTodayBalanceGameUseCase,
     private val submitBalanceGameChoiceUseCase: SubmitBalanceGameChoiceUseCase,
     savedStateHandle: SavedStateHandle,
-    crashlytics: CaramelCrashlytics
+    crashlytics: CaramelCrashlytics,
 ) : BaseViewModel<HomeState, HomeSideEffect, HomeIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): HomeState = HomeState()
 
@@ -59,7 +59,7 @@ class HomeViewModel(
 
     override fun handleClientException(throwable: Throwable) {
         super.handleClientException(throwable)
-        if(throwable is CaramelException){
+        if (throwable is CaramelException) {
             when (throwable.code) {
                 CoupleErrorCode.CAN_NOT_LOAD_DATA -> {
                     reduce {
@@ -105,7 +105,7 @@ class HomeViewModel(
             postSideEffect(
                 HomeSideEffect.ShowErrorDialog(
                     message = "알 수 없는 오류가 발생했습니다.",
-                    description = null
+                    description = null,
                 ),
             )
         }

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.home
 
 import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
 import com.whatever.caramel.core.domain.exception.code.CoupleErrorCode
@@ -28,7 +29,8 @@ class HomeViewModel(
     private val getTodayBalanceGameUseCase: GetTodayBalanceGameUseCase,
     private val submitBalanceGameChoiceUseCase: SubmitBalanceGameChoiceUseCase,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<HomeState, HomeSideEffect, HomeIntent>(savedStateHandle) {
+    crashlytics: CaramelCrashlytics
+) : BaseViewModel<HomeState, HomeSideEffect, HomeIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): HomeState = HomeState()
 
     override suspend fun handleIntent(intent: HomeIntent) {
@@ -57,48 +59,55 @@ class HomeViewModel(
 
     override fun handleClientException(throwable: Throwable) {
         super.handleClientException(throwable)
-
-        val exception = throwable as CaramelException
-
-        when (exception.code) {
-            CoupleErrorCode.CAN_NOT_LOAD_DATA -> {
-                reduce {
-                    copy(
-                        isShowBottomSheet = false,
-                        isShowDialog = true,
-                        dialogTitle = exception.message,
-                        coupleState = HomeState.CoupleState.DISCONNECT,
-                    )
-                }
-            }
-            CoupleErrorCode.MEMBER_NOT_FOUND -> {
-                if (currentState.coupleState != HomeState.CoupleState.DISCONNECT) {
+        if(throwable is CaramelException){
+            when (throwable.code) {
+                CoupleErrorCode.CAN_NOT_LOAD_DATA -> {
                     reduce {
                         copy(
+                            isShowBottomSheet = false,
                             isShowDialog = true,
-                            dialogTitle = exception.message,
+                            dialogTitle = throwable.message,
                             coupleState = HomeState.CoupleState.DISCONNECT,
                         )
                     }
                 }
-            }
-            else -> {
-                when (exception.errorUiType) {
-                    ErrorUiType.TOAST ->
-                        postSideEffect(
-                            HomeSideEffect.ShowErrorToast(
-                                message = throwable.message,
-                            ),
-                        )
-                    ErrorUiType.DIALOG ->
-                        postSideEffect(
-                            HomeSideEffect.ShowErrorDialog(
-                                message = throwable.message,
-                                description = throwable.description,
-                            ),
-                        )
+                CoupleErrorCode.MEMBER_NOT_FOUND -> {
+                    if (currentState.coupleState != HomeState.CoupleState.DISCONNECT) {
+                        reduce {
+                            copy(
+                                isShowDialog = true,
+                                dialogTitle = throwable.message,
+                                coupleState = HomeState.CoupleState.DISCONNECT,
+                            )
+                        }
+                    }
+                }
+                else -> {
+                    when (throwable.errorUiType) {
+                        ErrorUiType.TOAST ->
+                            postSideEffect(
+                                HomeSideEffect.ShowErrorToast(
+                                    message = throwable.message,
+                                ),
+                            )
+                        ErrorUiType.DIALOG ->
+                            postSideEffect(
+                                HomeSideEffect.ShowErrorDialog(
+                                    message = throwable.message,
+                                    description = throwable.description,
+                                ),
+                            )
+                    }
                 }
             }
+        } else {
+            caramelCrashlytics.recordException(throwable)
+            postSideEffect(
+                HomeSideEffect.ShowErrorDialog(
+                    message = "알 수 없는 오류가 발생했습니다.",
+                    description = null
+                ),
+            )
         }
     }
 

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -37,7 +37,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
             implementation(projects.core.firebaseMessaging)
 

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginViewModel.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.login
 
 import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
 import com.whatever.caramel.core.domain.usecase.auth.SignInWithSocialPlatformUseCase
@@ -16,9 +17,10 @@ import com.whatever.caramel.feature.login.social.kakao.KakaoUser
 
 class LoginViewModel(
     savedStateHandle: SavedStateHandle,
+    crashlytics : CaramelCrashlytics,
     private val signInWithSocialPlatformUseCase: SignInWithSocialPlatformUseCase,
     private val fcmTokenProvider: FcmTokenProvider,
-) : BaseViewModel<LoginState, LoginSideEffect, LoginIntent>(savedStateHandle) {
+) : BaseViewModel<LoginState, LoginSideEffect, LoginIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): LoginState = LoginState
 
     override suspend fun handleIntent(intent: LoginIntent) {
@@ -47,9 +49,11 @@ class LoginViewModel(
                     )
             }
         } else {
+            caramelCrashlytics.recordException(throwable)
             postSideEffect(
-                LoginSideEffect.ShowErrorToast(
-                    message = throwable.message ?: "알 수 없는 오류가 발생했습니다.",
+                LoginSideEffect.ShowErrorDialog(
+                    message = "알 수 없는 오류가 발생했습니다.",
+                    description = null
                 ),
             )
         }

--- a/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/whatever/caramel/feature/login/LoginViewModel.kt
@@ -17,7 +17,7 @@ import com.whatever.caramel.feature.login.social.kakao.KakaoUser
 
 class LoginViewModel(
     savedStateHandle: SavedStateHandle,
-    crashlytics : CaramelCrashlytics,
+    crashlytics: CaramelCrashlytics,
     private val signInWithSocialPlatformUseCase: SignInWithSocialPlatformUseCase,
     private val fcmTokenProvider: FcmTokenProvider,
 ) : BaseViewModel<LoginState, LoginSideEffect, LoginIntent>(savedStateHandle, crashlytics) {
@@ -53,7 +53,7 @@ class LoginViewModel(
             postSideEffect(
                 LoginSideEffect.ShowErrorDialog(
                     message = "알 수 없는 오류가 발생했습니다.",
-                    description = null
+                    description = null,
                 ),
             )
         }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
             implementation(projects.core.firebaseMessaging)
 

--- a/feature/main/src/commonMain/kotlin/com/whatever/caramel/feature/main/MainViewModel.kt
+++ b/feature/main/src/commonMain/kotlin/com/whatever/caramel/feature/main/MainViewModel.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.main
 
 import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.firebaseMessaging.FcmTokenProvider
 import com.whatever.caramel.core.viewmodel.BaseViewModel
 import com.whatever.caramel.feature.main.mvi.MainIntent
@@ -10,7 +11,8 @@ import com.whatever.caramel.feature.main.mvi.MainState
 class MainViewModel(
     private val fcmTokenProvider: FcmTokenProvider,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<MainState, MainSideEffect, MainIntent>(savedStateHandle) {
+    crashlytics : CaramelCrashlytics
+) : BaseViewModel<MainState, MainSideEffect, MainIntent>(savedStateHandle, crashlytics) {
     override fun handleClientException(throwable: Throwable) {
         super.handleClientException(throwable)
     }

--- a/feature/main/src/commonMain/kotlin/com/whatever/caramel/feature/main/MainViewModel.kt
+++ b/feature/main/src/commonMain/kotlin/com/whatever/caramel/feature/main/MainViewModel.kt
@@ -11,7 +11,7 @@ import com.whatever.caramel.feature.main.mvi.MainState
 class MainViewModel(
     private val fcmTokenProvider: FcmTokenProvider,
     savedStateHandle: SavedStateHandle,
-    crashlytics : CaramelCrashlytics
+    crashlytics: CaramelCrashlytics,
 ) : BaseViewModel<MainState, MainSideEffect, MainIntent>(savedStateHandle, crashlytics) {
     override fun handleClientException(throwable: Throwable) {
         super.handleClientException(throwable)

--- a/feature/memo/build.gradle.kts
+++ b/feature/memo/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
             implementation(projects.core.util)
 

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoViewModel.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoViewModel.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.memo
 
 import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
 import com.whatever.caramel.core.domain.usecase.content.GetMemosUseCase
@@ -18,7 +19,8 @@ class MemoViewModel(
     private val getMemosUseCase: GetMemosUseCase,
     private val getTagUseCase: GetTagUseCase,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<MemoState, MemoSideEffect, MemoIntent>(savedStateHandle) {
+    crashlytics : CaramelCrashlytics
+) : BaseViewModel<MemoState, MemoSideEffect, MemoIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): MemoState = MemoState()
 
     override suspend fun handleIntent(intent: MemoIntent) {
@@ -57,9 +59,11 @@ class MemoViewModel(
                     )
             }
         } else {
+            caramelCrashlytics.recordException(throwable)
             postSideEffect(
-                MemoSideEffect.ShowErrorToast(
-                    message = throwable.message ?: "알 수 없는 오류가 발생했습니다.",
+                MemoSideEffect.ShowErrorDialog(
+                    message = "알 수 없는 오류가 발생했습니다.",
+                    description = null
                 ),
             )
         }

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoViewModel.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoViewModel.kt
@@ -19,7 +19,7 @@ class MemoViewModel(
     private val getMemosUseCase: GetMemosUseCase,
     private val getTagUseCase: GetTagUseCase,
     savedStateHandle: SavedStateHandle,
-    crashlytics : CaramelCrashlytics
+    crashlytics: CaramelCrashlytics,
 ) : BaseViewModel<MemoState, MemoSideEffect, MemoIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): MemoState = MemoState()
 
@@ -63,7 +63,7 @@ class MemoViewModel(
             postSideEffect(
                 MemoSideEffect.ShowErrorDialog(
                     message = "알 수 없는 오류가 발생했습니다.",
-                    description = null
+                    description = null,
                 ),
             )
         }

--- a/feature/profile/create/build.gradle.kts
+++ b/feature/profile/create/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
             implementation(projects.core.util)
 

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateViewModel.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateViewModel.kt
@@ -23,7 +23,7 @@ class ProfileCreateViewModel(
     private val updateUserSettingUseCase: UpdateUserSettingUseCase,
     private val permissionsController: PermissionsController,
     savedStateHandle: SavedStateHandle,
-    crashlytics: CaramelCrashlytics
+    crashlytics: CaramelCrashlytics,
 ) : BaseViewModel<ProfileCreateState, ProfileCreateSideEffect, ProfileCreateIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): ProfileCreateState = ProfileCreateState()
 
@@ -71,7 +71,7 @@ class ProfileCreateViewModel(
             postSideEffect(
                 ProfileCreateSideEffect.ShowErrorDialog(
                     message = "알 수 없는 오류가 발생했습니다.",
-                    description = null
+                    description = null,
                 ),
             )
         }

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateViewModel.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateViewModel.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.profile.create
 
 import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
 import com.whatever.caramel.core.domain.usecase.user.CreateUserProfileUseCase
@@ -22,7 +23,8 @@ class ProfileCreateViewModel(
     private val updateUserSettingUseCase: UpdateUserSettingUseCase,
     private val permissionsController: PermissionsController,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<ProfileCreateState, ProfileCreateSideEffect, ProfileCreateIntent>(savedStateHandle) {
+    crashlytics: CaramelCrashlytics
+) : BaseViewModel<ProfileCreateState, ProfileCreateSideEffect, ProfileCreateIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): ProfileCreateState = ProfileCreateState()
 
     override suspend fun handleIntent(intent: ProfileCreateIntent) {
@@ -65,9 +67,11 @@ class ProfileCreateViewModel(
                     )
             }
         } else {
+            caramelCrashlytics.recordException(throwable)
             postSideEffect(
-                ProfileCreateSideEffect.ShowErrorToast(
-                    message = throwable.message ?: "알 수 없는 오류가 발생했습니다.",
+                ProfileCreateSideEffect.ShowErrorDialog(
+                    message = "알 수 없는 오류가 발생했습니다.",
+                    description = null
                 ),
             )
         }

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/di/Module.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/di/Module.kt
@@ -13,6 +13,7 @@ val profileCreateFeatureModule =
                 createUserProfileUseCase = get(),
                 updateUserSettingUseCase = get(),
                 permissionsController = permissionsController,
+                crashlytics = get()
             )
         }
     }

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/di/Module.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/di/Module.kt
@@ -13,7 +13,7 @@ val profileCreateFeatureModule =
                 createUserProfileUseCase = get(),
                 updateUserSettingUseCase = get(),
                 permissionsController = permissionsController,
-                crashlytics = get()
+                crashlytics = get(),
             )
         }
     }

--- a/feature/profile/edit/build.gradle.kts
+++ b/feature/profile/edit/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
             implementation(projects.core.util)
 

--- a/feature/profile/edit/src/commonMain/kotlin/com/whatever/caramel/feature/profile/edit/ProfileEditViewModel.kt
+++ b/feature/profile/edit/src/commonMain/kotlin/com/whatever/caramel/feature/profile/edit/ProfileEditViewModel.kt
@@ -21,7 +21,7 @@ class ProfileEditViewModel(
     private val editProfileUseCase: EditProfileUseCase,
     private val editCoupleStartDateUseCase: EditCoupleStartDateUseCase,
     savedStateHandle: SavedStateHandle,
-    crashlytics : CaramelCrashlytics
+    crashlytics: CaramelCrashlytics,
 ) : BaseViewModel<ProfileEditState, ProfileEditSideEffect, ProfileEditIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): ProfileEditState {
         val arguments = savedStateHandle.toRoute<ProfileEditRoute>()
@@ -80,7 +80,7 @@ class ProfileEditViewModel(
             postSideEffect(
                 ProfileEditSideEffect.ShowErrorDialog(
                     message = "알 수 없는 오류가 발생했습니다.",
-                    description = null
+                    description = null,
                 ),
             )
         }

--- a/feature/profile/edit/src/commonMain/kotlin/com/whatever/caramel/feature/profile/edit/ProfileEditViewModel.kt
+++ b/feature/profile/edit/src/commonMain/kotlin/com/whatever/caramel/feature/profile/edit/ProfileEditViewModel.kt
@@ -2,6 +2,7 @@ package com.whatever.caramel.feature.profile.edit
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
 import com.whatever.caramel.core.domain.usecase.couple.EditCoupleStartDateUseCase
@@ -20,7 +21,8 @@ class ProfileEditViewModel(
     private val editProfileUseCase: EditProfileUseCase,
     private val editCoupleStartDateUseCase: EditCoupleStartDateUseCase,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<ProfileEditState, ProfileEditSideEffect, ProfileEditIntent>(savedStateHandle) {
+    crashlytics : CaramelCrashlytics
+) : BaseViewModel<ProfileEditState, ProfileEditSideEffect, ProfileEditIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): ProfileEditState {
         val arguments = savedStateHandle.toRoute<ProfileEditRoute>()
         return ProfileEditState(
@@ -74,9 +76,11 @@ class ProfileEditViewModel(
                     )
             }
         } else {
+            caramelCrashlytics.recordException(throwable)
             postSideEffect(
-                ProfileEditSideEffect.ShowErrorToast(
-                    message = throwable.message ?: "알 수 없는 오류가 발생했습니다.",
+                ProfileEditSideEffect.ShowErrorDialog(
+                    message = "알 수 없는 오류가 발생했습니다.",
+                    description = null
                 ),
             )
         }

--- a/feature/setting/build.gradle.kts
+++ b/feature/setting/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
             implementation(projects.core.util)
 

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingViewModel.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingViewModel.kt
@@ -23,7 +23,7 @@ class SettingViewModel(
     private val logoutUseCase: LogoutUseCase,
     private val signOutUseCase: SignOutUseCase,
     savedStateHandle: SavedStateHandle,
-    crashlytics: CaramelCrashlytics
+    crashlytics: CaramelCrashlytics,
 ) : BaseViewModel<SettingState, SettingSideEffect, SettingIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): SettingState = SettingState()
 
@@ -75,7 +75,7 @@ class SettingViewModel(
             postSideEffect(
                 SettingSideEffect.ShowErrorDialog(
                     message = "알 수 없는 오류가 발생했습니다.",
-                    description = null
+                    description = null,
                 ),
             )
         }

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingViewModel.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingViewModel.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.setting
 
 import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
 import com.whatever.caramel.core.domain.usecase.auth.LogoutUseCase
@@ -22,7 +23,8 @@ class SettingViewModel(
     private val logoutUseCase: LogoutUseCase,
     private val signOutUseCase: SignOutUseCase,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<SettingState, SettingSideEffect, SettingIntent>(savedStateHandle) {
+    crashlytics: CaramelCrashlytics
+) : BaseViewModel<SettingState, SettingSideEffect, SettingIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): SettingState = SettingState()
 
     override suspend fun handleIntent(intent: SettingIntent) {
@@ -69,9 +71,11 @@ class SettingViewModel(
                     )
             }
         } else {
+            caramelCrashlytics.recordException(throwable)
             postSideEffect(
-                SettingSideEffect.ShowErrorToast(
-                    message = throwable.message ?: "알 수 없는 오류가 발생했습니다.",
+                SettingSideEffect.ShowErrorDialog(
+                    message = "알 수 없는 오류가 발생했습니다.",
+                    description = null
                 ),
             )
         }

--- a/feature/splash/build.gradle.kts
+++ b/feature/splash/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.designsystem)
             implementation(projects.core.ui)
-            implementation(projects.core.analytics)
+            implementation(projects.core.crashlytics)
             implementation(projects.core.viewmodel)
             implementation(projects.core.deeplink)
 

--- a/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/SplashViewModel.kt
+++ b/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/SplashViewModel.kt
@@ -1,7 +1,9 @@
 package com.whatever.caramel.feature.splash
 
 import androidx.lifecycle.SavedStateHandle
+import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.deeplink.DeepLinkHandler
+import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.usecase.user.RefreshUserSessionUseCase
 import com.whatever.caramel.core.viewmodel.BaseViewModel
 import com.whatever.caramel.feature.splash.mvi.SplashIntent
@@ -13,7 +15,8 @@ class SplashViewModel(
     private val refreshUserSessionUseCase: RefreshUserSessionUseCase,
     private val deepLinkHandler: DeepLinkHandler,
     savedStateHandle: SavedStateHandle,
-) : BaseViewModel<SplashState, SplashSideEffect, SplashIntent>(savedStateHandle) {
+    crashlytics: CaramelCrashlytics
+) : BaseViewModel<SplashState, SplashSideEffect, SplashIntent>(savedStateHandle, crashlytics) {
     init {
         launch {
             delay(1000L)
@@ -25,6 +28,9 @@ class SplashViewModel(
 
     override fun handleClientException(throwable: Throwable) {
         super.handleClientException(throwable)
+        if(throwable !is CaramelException) {
+            caramelCrashlytics.recordException(throwable)
+        }
         postSideEffect(SplashSideEffect.NavigateToLogin)
     }
 

--- a/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/SplashViewModel.kt
+++ b/feature/splash/src/commonMain/kotlin/com/whatever/caramel/feature/splash/SplashViewModel.kt
@@ -15,7 +15,7 @@ class SplashViewModel(
     private val refreshUserSessionUseCase: RefreshUserSessionUseCase,
     private val deepLinkHandler: DeepLinkHandler,
     savedStateHandle: SavedStateHandle,
-    crashlytics: CaramelCrashlytics
+    crashlytics: CaramelCrashlytics,
 ) : BaseViewModel<SplashState, SplashSideEffect, SplashIntent>(savedStateHandle, crashlytics) {
     init {
         launch {
@@ -28,7 +28,7 @@ class SplashViewModel(
 
     override fun handleClientException(throwable: Throwable) {
         super.handleClientException(throwable)
-        if(throwable !is CaramelException) {
+        if (throwable !is CaramelException) {
             caramelCrashlytics.recordException(throwable)
         }
         postSideEffect(SplashSideEffect.NavigateToLogin)


### PR DESCRIPTION
## 작업한 내용
- feature 모듈에 analytics 모듈 제거 (추후 필요한 부분에 적용)
- viewModel/feature 모듈에 Crashyltics 모듈에 대한 의존성 추가
- intent 로깅과 Exception 핸들링을 위한 ViewModel에 Crashlytics를 DI

## PR 포인트
### 1. recordException 위치 변경
- 회의 결과 Exception에 대한 처리는 ViewModel에서 하는 것으로 되어 기존 safeCall -> ViewModel > handleClientException 으로 변경되었습니다. 
- intent에 대한 로깅은 BaseViewModel, recordException은 CaramelException이 아닌 경우 보내도록 합니다.
- recordException의 경우 debug에서도 작동하면 로깅에 어려움이 있어 release에서만 동작하도록 변경하였습니다.
```
abstract class BaseViewModel<S : UiState, SE : UiSideEffect, I : UiIntent>(
    val savedStateHandle: SavedStateHandle,
    protected val caramelCrashlytics: CaramelCrashlytics,
) : ViewModel() {
    fun intent(intent: I) {
        launch {
            caramelCrashlytics.log("${this@BaseViewModel::class.simpleName} > received intent : $intent")
            handleIntent(intent)
        }
    }
}
```
handleClientException도 BaseViewModel에서 하기에는 CaramelException이 domain 모듈이기에 handleClientException은 각 모듈별로 처리하였습니다.
### 2. safeCall 원복
safeCall에서 recordException을 하지 않기에 다시 원복했습니다. `IOException`이나 `TimeoutCancellationException`의 경우는 CaramelException으로 변환하였습니다.
### 3. iOS의 로깅 타이틀 변경
<img width="725" height="273" alt="image" src="https://github.com/user-attachments/assets/3a2a97a5-a79e-4e38-888a-df9df31c2469" />

기존 iOS에서는 `KotlinException`으로 로깅하고 있었는데 항목추가가 아닌 "변형"으로 나오고 있어 예외 클래스 항목을 추가했습니다.

## 공유사항
HomeViewModel이나 CaramelViewModel에서 구현해주신 handleClientException에 변경점이 존재합니다.

`val exception = throwable as CaramelException`
이전에는 throwable을 CaramelExceptoin으로 형변환이 되고 있었습니다. 현재는 해당 부분에 다른 예외 클래스도 들어올 수 있어 다른 feature 모듈과 동일하게 수정되었습니다.