### PR TITLE
[QA] 로그아웃, 회원탈퇴 시 백스택에 홈 화면이 남아있는 오류 수정

### DIFF
--- a/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
+++ b/app/src/commonMain/kotlin/com/whatever/caramel/app/CaramelNavHost.kt
@@ -122,7 +122,7 @@ internal fun CaramelNavHost(
                 },
                 navigateToLogin = {
                     navigateToLogin {
-                        popUpTo(SettingRoute) {
+                        popUpTo(0) {
                             inclusive = true
                         }
                     }


### PR DESCRIPTION
## 관련 이슈
- [설정 - 로그아웃 시 시스템 뒤로가기 동작 오류](https://www.notion.so/given-dragon/QA-Board-205870f222b9804f8356ce9332a73263?p=22a870f222b98045a955d66e71e51da0&pm=s)

## 작업한 내용
- 셋팅 화면에서 로그인 화면으로 넘어갈 때 백스택에 홈화면 남아있던 오류 수정
