### PR TITLE
[QA] 컨텐츠 - 일정 변경 시 시간 오류

### DIFF
--- a/core/util/src/commonMain/kotlin/com/whatever/caramel/core/util/TimeUtil.kt
+++ b/core/util/src/commonMain/kotlin/com/whatever/caramel/core/util/TimeUtil.kt
@@ -1,0 +1,25 @@
+package com.whatever.caramel.core.util
+
+import kotlinx.datetime.LocalDateTime
+
+object TimeUtil {
+    /**
+     * 현재 LocalDateTime을 5분 단위로 반올림해서 반환합니다.
+     *
+     * @author GunHyung-Ham
+     * @param dateTime LocalDateTime 타입
+     * @return 5분 단위로 반올림된 LocalDateTime (초와 나노초는 0으로 초기화)
+     */
+    fun roundToNearest5Minutes(dateTime: LocalDateTime): LocalDateTime {
+        val roundedMinute = ((dateTime.minute + 2) / 5) * 5
+        val adjustedHour = if (roundedMinute >= 60) dateTime.hour + 1 else dateTime.hour
+        val finalMinute = if (roundedMinute >= 60) 0 else roundedMinute
+
+        return dateTime.copy(
+            hour = adjustedHour,
+            minute = finalMinute,
+            second = 0,
+            nanosecond = 0,
+        )
+    }
+}

--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
@@ -13,6 +13,7 @@ import com.whatever.caramel.core.domain.vo.content.ContentType
 import com.whatever.caramel.core.domain.vo.memo.MemoParameter
 import com.whatever.caramel.core.ui.content.CreateMode
 import com.whatever.caramel.core.util.DateUtil
+import com.whatever.caramel.core.util.TimeUtil.roundToNearest5Minutes
 import com.whatever.caramel.core.util.copy
 import com.whatever.caramel.core.viewmodel.BaseViewModel
 import com.whatever.caramel.feature.content.create.mvi.ContentCreateIntent
@@ -21,10 +22,8 @@ import com.whatever.caramel.feature.content.create.mvi.ContentCreateState
 import com.whatever.caramel.feature.content.create.navigation.ContentCreateRoute
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
-import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 
 class ContentCreateViewModel(
     crashlytics: CaramelCrashlytics,
@@ -43,9 +42,10 @@ class ContentCreateViewModel(
 
     override fun createInitialState(savedStateHandle: SavedStateHandle): ContentCreateState {
         val arguments = savedStateHandle.toRoute<ContentCreateRoute>()
-        val dateTime =
+        val dateTime: LocalDateTime =
             if (arguments.dateTimeString.isEmpty()) {
-                DateUtil.todayLocalDateTime()
+                val now = DateUtil.todayLocalDateTime()
+                roundToNearest5Minutes(dateTime = now)
             } else {
                 LocalDateTime.parse(
                     arguments.dateTimeString,
@@ -171,17 +171,8 @@ class ContentCreateViewModel(
                 createMode = intent.createMode,
                 dateTime =
                     if (intent.createMode == CreateMode.CALENDAR) {
-                        val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
-                        val roundedMinute = ((now.minute + 2) / 5) * 5
-                        val adjustedHour = if (roundedMinute >= 60) now.hour + 1 else now.hour
-                        val finalMinute = if (roundedMinute >= 60) 0 else roundedMinute
-
-                        now.copy(
-                            hour = adjustedHour,
-                            minute = finalMinute,
-                            second = 0,
-                            nanosecond = 0,
-                        )
+                        val now = DateUtil.todayLocalDateTime()
+                        roundToNearest5Minutes(dateTime = now)
                     } else {
                         dateTime
                     },


### PR DESCRIPTION
## 관련 이슈
- [컨텐츠 - 일정 변경 시 시간 오류](https://www.notion.so/given-dragon/QA-Board-205870f222b9804f8356ce9332a73263?p=205870f222b98092bc79ecc5f63c5cd4&pm=s)

## 작업한 내용
- 홈 화면에서 '오늘 일정' 생성할 때 분단위 5분 단위로 반올림하여 출력
  - `기존` : 31분, 47분, 33분 등 1의자리까지 보여줌
  - `변경` : 30분, 45분, 35분 등 5분 단위로 반올림하여 표시

## PR 포인트
- :util 모듈에서 TimeUtil 함수 추가
```kotlin
object TimeUtil {
    /**
     * 현재 LocalDateTime을 5분 단위로 반올림해서 반환합니다.
     *
     * @author GunHyung-Ham
     * @param dateTime LocalDateTime 타입
     * @return 5분 단위로 반올림된 LocalDateTime (초와 나노초는 0으로 초기화)
     */
    fun roundToNearest5Minutes(dateTime: LocalDateTime): LocalDateTime {
        val roundedMinute = ((dateTime.minute + 2) / 5) * 5
        val adjustedHour = if (roundedMinute >= 60) dateTime.hour + 1 else dateTime.hour
        val finalMinute = if (roundedMinute >= 60) 0 else roundedMinute

        return dateTime.copy(
            hour = adjustedHour,
            minute = finalMinute,
            second = 0,
            nanosecond = 0,
        )
    }
}
```