### PR TITLE
[Feat] API 요청시 타임존 헤더 추가

### DIFF
--- a/core/remote/src/androidMain/kotlin/com/whatever/caramel/core/remote/network/config/TimeZoneHeader.android.kt
+++ b/core/remote/src/androidMain/kotlin/com/whatever/caramel/core/remote/network/config/TimeZoneHeader.android.kt
@@ -1,4 +1,6 @@
 package com.whatever.caramel.core.remote.network.config
 
 actual fun currentTimeZone(): String =
-    java.util.TimeZone.getDefault().id
+    java.util.TimeZone
+        .getDefault()
+        .id

--- a/core/remote/src/androidMain/kotlin/com/whatever/caramel/core/remote/network/config/TimeZoneHeader.android.kt
+++ b/core/remote/src/androidMain/kotlin/com/whatever/caramel/core/remote/network/config/TimeZoneHeader.android.kt
@@ -1,0 +1,4 @@
+package com.whatever.caramel.core.remote.network.config
+
+actual fun currentTimeZone(): String =
+    java.util.TimeZone.getDefault().id

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/di/Module.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/di/Module.kt
@@ -24,6 +24,7 @@ import com.whatever.caramel.core.remote.di.qualifier.SampleClient
 import com.whatever.caramel.core.remote.network.HttpClientFactory
 import com.whatever.caramel.core.remote.network.config.NetworkConfig
 import com.whatever.caramel.core.remote.network.config.addDeviceIdHeader
+import com.whatever.caramel.core.remote.network.config.addTimeZoneHeader
 import com.whatever.caramel.core.remote.network.config.caramelDefaultRequest
 import com.whatever.caramel.core.remote.network.config.caramelResponseValidator
 import com.whatever.caramel.core.remote.network.interceptor.TokenInterceptor
@@ -58,6 +59,7 @@ val networkModule =
         single(DefaultClient) {
             get<HttpClient>().config {
                 addDeviceIdHeader(get())
+                addTimeZoneHeader()
                 caramelResponseValidator()
                 caramelDefaultRequest()
             }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/network/config/TimeZoneHeader.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/network/config/TimeZoneHeader.kt
@@ -1,0 +1,15 @@
+package com.whatever.caramel.core.remote.network.config
+
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.request.HttpRequestPipeline
+
+expect fun currentTimeZone(): String
+
+fun HttpClientConfig<*>.addTimeZoneHeader() {
+    install("AddTimeZoneHeader") {
+        requestPipeline.intercept(HttpRequestPipeline.State) {
+            context.headers.append(Header.TIME_ZONE, currentTimeZone())
+            proceed()
+        }
+    }
+}

--- a/core/remote/src/iosMain/kotlin/com/whatever/caramel/core/remote/network/config/TimeZoneHeader.ios.kt
+++ b/core/remote/src/iosMain/kotlin/com/whatever/caramel/core/remote/network/config/TimeZoneHeader.ios.kt
@@ -2,5 +2,4 @@ package com.whatever.caramel.core.remote.network.config
 
 import platform.Foundation.localTimeZone
 
-actual fun currentTimeZone(): String =
-    platform.Foundation.NSTimeZone.localTimeZone.name
+actual fun currentTimeZone(): String = platform.Foundation.NSTimeZone.localTimeZone.name

--- a/core/remote/src/iosMain/kotlin/com/whatever/caramel/core/remote/network/config/TimeZoneHeader.ios.kt
+++ b/core/remote/src/iosMain/kotlin/com/whatever/caramel/core/remote/network/config/TimeZoneHeader.ios.kt
@@ -1,0 +1,6 @@
+package com.whatever.caramel.core.remote.network.config
+
+import platform.Foundation.localTimeZone
+
+actual fun currentTimeZone(): String =
+    platform.Foundation.NSTimeZone.localTimeZone.name


### PR DESCRIPTION
## 관련 이슈
- [프로필 생성 > 생일에 미래시 적용](https://www.notion.so/given-dragon/QA-Board-205870f222b9804f8356ce9332a73263?p=213870f222b980c7bc66f5cebfe2bf33&pm=s)

## 작업한 내용
- DefaultClient에 타임존 헤더 추가
