### PR TITLE
[Fix] iOS - 바텀시트 내부에 텍스트필드 존재시 하단 여백 생기던 오류 수정

### DIFF
--- a/app/src/iosMain/kotlin/com/whatever/caramel/MainViewController.kt
+++ b/app/src/iosMain/kotlin/com/whatever/caramel/MainViewController.kt
@@ -2,6 +2,7 @@
 
 package com.whatever.caramel
 
+import androidx.compose.ui.uikit.OnFocusBehavior
 import androidx.compose.ui.window.ComposeUIViewController
 import androidx.navigation.compose.rememberNavController
 import com.whatever.caramel.app.CaramelComposeApp
@@ -13,7 +14,10 @@ import kotlin.experimental.ExperimentalNativeApi
 @OptIn(ExperimentalNativeApi::class)
 fun mainViewController() =
     ComposeUIViewController(
-        configure = { initKoin() },
+        configure = {
+            initKoin()
+            onFocusBehavior = OnFocusBehavior.DoNothing
+        },
     ) {
         if (Platform.isDebugBinary) {
             Napier.base(DebugAntilog())


### PR DESCRIPTION
## 작업한 내용
- 홈 - 공유 메세지 바텀시트 올라올때 하단 여백 생기던 오류 수정
