### PR TITLE
[Fix] ObserveLifecycleEvent를 활용한 API 호출 시점 변경

### DIFF
--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarRoute.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarRoute.kt
@@ -35,7 +35,7 @@ internal fun CalendarRoute(
     }
 
     ObserveLifecycleEvent { event ->
-        if (event == Lifecycle.Event.ON_START) {
+        if (event == Lifecycle.Event.ON_RESUME) {
             viewModel.intent(CalendarIntent.Initialize)
         }
     }

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailRoute.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailRoute.kt
@@ -49,7 +49,7 @@ internal fun ContentDetailRoute(
     }
 
     ObserveLifecycleEvent { event ->
-        if (event == Lifecycle.Event.ON_START) {
+        if (event == Lifecycle.Event.ON_RESUME) {
             viewModel.intent(ContentDetailIntent.LoadDataOnStart)
         }
     }

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeRoute.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeRoute.kt
@@ -47,7 +47,7 @@ internal fun HomeRoute(
     }
 
     ObserveLifecycleEvent { event ->
-        if (event == Lifecycle.Event.ON_START) {
+        if (event == Lifecycle.Event.ON_RESUME) {
             viewModel.intent(HomeIntent.LoadDataOnStart)
         }
     }

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoRoute.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoRoute.kt
@@ -31,7 +31,7 @@ internal fun MemoRoute(
     }
 
     ObserveLifecycleEvent { event ->
-        if (event == Lifecycle.Event.ON_START) {
+        if (event == Lifecycle.Event.ON_RESUME) {
             viewModel.intent(MemoIntent.Initialize)
         }
     }

--- a/feature/setting/src/androidMain/kotlin/com/whatever/caramel/feature/setting/component/preview/UserProfilePreview.kt
+++ b/feature/setting/src/androidMain/kotlin/com/whatever/caramel/feature/setting/component/preview/UserProfilePreview.kt
@@ -4,13 +4,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
 import com.whatever.caramel.core.domain.vo.user.Gender
-import com.whatever.caramel.feature.setting.component.SettingUserProfile
+import com.whatever.caramel.feature.setting.component.SettingUserProfileContent
 
 @Preview(showBackground = true)
 @Composable
 fun UserProfilePreview() {
     CaramelTheme {
-        SettingUserProfile(
+        SettingUserProfileContent(
             gender = Gender.FEMALE,
             nickname = "유승우",
             birthDay = "1997.11.18",

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingRoute.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingRoute.kt
@@ -30,7 +30,7 @@ internal fun SettingRoute(
     val termsOfServiceUrl = stringResource(Resources.String.terms_of_service_url)
 
     ObserveLifecycleEvent { event ->
-        if (event == Lifecycle.Event.ON_START) {
+        if (event == Lifecycle.Event.ON_RESUME) {
             viewModel.intent(SettingIntent.RefreshCoupleData)
         }
     }

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/SettingScreen.kt
@@ -35,7 +35,6 @@ import com.whatever.caramel.feature.setting.component.SettingEditProfileBottomSh
 import com.whatever.caramel.feature.setting.component.SettingListButton
 import com.whatever.caramel.feature.setting.component.SettingListText
 import com.whatever.caramel.feature.setting.component.SettingUserProfile
-import com.whatever.caramel.feature.setting.component.SettingUserProfileSkeleton
 import com.whatever.caramel.feature.setting.mvi.SettingIntent
 import com.whatever.caramel.feature.setting.mvi.SettingState
 import com.whatever.caramel.feature.setting.util.Platform
@@ -133,26 +132,22 @@ internal fun SettingScreen(
                     )
                 }
                 Spacer(modifier = Modifier.padding(bottom = 20.dp))
-                if (state.isLoading) {
-                    SettingUserProfileSkeleton()
-                    Spacer(modifier = Modifier.padding(bottom = CaramelTheme.spacing.m))
-                    SettingUserProfileSkeleton()
-                } else {
-                    SettingUserProfile(
-                        gender = state.myInfo.gender,
-                        nickname = state.myInfo.nickname,
-                        birthDay = state.myInfo.birthday,
-                        isEditable = true,
-                        onClickEditProfile = { onIntent(SettingIntent.ToggleEditProfile) },
-                    )
-                    Spacer(modifier = Modifier.padding(bottom = CaramelTheme.spacing.m))
-                    SettingUserProfile(
-                        gender = state.partnerInfo.gender,
-                        nickname = state.partnerInfo.nickname,
-                        birthDay = state.partnerInfo.birthday,
-                        isEditable = false,
-                    )
-                }
+                SettingUserProfile(
+                    isLoading = state.isLoading,
+                    gender = state.myInfo.gender,
+                    nickname = state.myInfo.nickname,
+                    birthDay = state.myInfo.birthday,
+                    isEditable = true,
+                    onClickEditProfile = { onIntent(SettingIntent.ToggleEditProfile) },
+                )
+                Spacer(modifier = Modifier.padding(bottom = CaramelTheme.spacing.m))
+                SettingUserProfile(
+                    isLoading = state.isLoading,
+                    gender = state.partnerInfo.gender,
+                    nickname = state.partnerInfo.nickname,
+                    birthDay = state.partnerInfo.birthday,
+                    isEditable = false,
+                )
             }
             HorizontalDivider(
                 modifier =

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/component/UserProfile.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/component/UserProfile.kt
@@ -25,6 +25,30 @@ import org.jetbrains.compose.resources.painterResource
 @Composable
 internal fun SettingUserProfile(
     modifier: Modifier = Modifier,
+    isLoading: Boolean,
+    gender: Gender,
+    nickname: String,
+    birthDay: String,
+    isEditable: Boolean,
+    onClickEditProfile: (() -> Unit)? = null,
+) {
+    if (isLoading) {
+        SettingUserProfileSkeleton()
+    } else {
+        SettingUserProfileContent(
+            modifier = modifier,
+            gender = gender,
+            nickname = nickname,
+            birthDay = birthDay,
+            isEditable = isEditable,
+            onClickEditProfile = onClickEditProfile,
+        )
+    }
+}
+
+@Composable
+internal fun SettingUserProfileContent(
+    modifier: Modifier = Modifier,
     gender: Gender,
     nickname: String,
     birthDay: String,
@@ -36,7 +60,6 @@ internal fun SettingUserProfile(
             Gender.IDLE, Gender.MALE -> Resources.Image.img_gender_man
             Gender.FEMALE -> Resources.Image.img_gender_woman
         }
-
     Row(
         modifier =
             modifier
@@ -53,7 +76,6 @@ internal fun SettingUserProfile(
             painter = painterResource(genderImageResource),
             tint = Color.Unspecified,
         )
-
         Spacer(modifier = Modifier.size(size = CaramelTheme.spacing.m))
         Column(
             modifier =
@@ -104,7 +126,13 @@ internal fun SettingUserProfile(
 @Composable
 internal fun SettingUserProfileSkeleton(modifier: Modifier = Modifier) {
     Row(
-        modifier = modifier,
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(
+                    color = CaramelTheme.color.fill.inverse,
+                    shape = CaramelTheme.shape.xl,
+                ).padding(all = CaramelTheme.spacing.m),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(

--- a/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/mvi/SettingState.kt
+++ b/feature/setting/src/commonMain/kotlin/com/whatever/caramel/feature/setting/mvi/SettingState.kt
@@ -5,7 +5,7 @@ import com.whatever.caramel.core.domain.vo.user.Gender
 import com.whatever.caramel.core.viewmodel.UiState
 
 data class SettingState(
-    val isLoading: Boolean = false,
+    val isLoading: Boolean = true,
     val startDate: String = "",
     val myInfo: CoupleUser = CoupleUser(),
     val partnerInfo: CoupleUser = CoupleUser(),


### PR DESCRIPTION
## 작업한 내용
- ObserveLifecycleEvent를 통한 API 호출 시점 변경 (ON_START -> ON_RESUME)
- 설정 > 프로필 UI의 Skelton UI 오류 수정

https://github.com/user-attachments/assets/3bc3aeb9-94fb-485a-84fe-df4849333c3c

## 공유사항
ON_START -> ON_RESUME으로 변경됨에 따라 API 호출 시점이 살짝 늦어졌습니다.
추후에도 이런 부분이 있다면 Skelton으로 UI에 이상없게 구현해야 할 것 같아요!