### PR TITLE
[Fix] 이슈 종료시 슬랙 알림 메시지 줄바꿈 오류 수정

### DIFF
--- a/.github/workflows/issue-closed.yml
+++ b/.github/workflows/issue-closed.yml
@@ -40,8 +40,11 @@ jobs:
             LINKED_PRS="연결된 PR이 없습니다!"
           fi
 
-          ISSUE_SECTION="*[<${ISSUE_URL}|#${ISSUE_NUMBER}>]*\n${ISSUE_TITLE}\n\n${LINKED_PRS}"          
           HEADER_TEXT="🗑️ 이슈 종료"
+          
+          ISSUE_SECTION="*[<${ISSUE_URL}|#${ISSUE_NUMBER}>]*
+          ${ISSUE_TITLE}
+          ${LINKED_PRS}"
 
           echo "header_text=$(printf "%s" "$HEADER_TEXT" | jq -Rs .)" >> $GITHUB_OUTPUT
           echo "issue_section=$(printf "%s" "$ISSUE_SECTION" | jq -Rs .)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 작업한 내용
- 이슈 종료 슬랙 알림 메세지 수정

## PR 포인트
- 슬랙으로 메세지 보낼 때 개행 방법
  ```bash
  ISSUE_SECTION="*[<${ISSUE_URL}|#${ISSUE_NUMBER}>]*
  ${ISSUE_TITLE}
  ${LINKED_PRS}"
  ```
  `\n` 개행 문자 없이 실제 코드상 줄바꿈을 적용해야 슬랙 메세지에 적용됩니다.]