### PR TITLE
[Fix] 설정 - 커플 시작일 API 타임존 헤더 중복 제거

### DIFF
--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/repository/CoupleRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/repository/CoupleRepositoryImpl.kt
@@ -15,7 +15,6 @@ import com.whatever.caramel.core.remote.datasource.RemoteCoupleDataSource
 import com.whatever.caramel.core.remote.dto.couple.request.CoupleConnectRequest
 import com.whatever.caramel.core.remote.dto.couple.request.CoupleSharedMessageRequest
 import com.whatever.caramel.core.remote.dto.couple.request.CoupleStartDateUpdateRequest
-import kotlinx.datetime.TimeZone
 
 class CoupleRepositoryImpl(
     private val localCoupleDataSource: CoupleDataSource,
@@ -63,7 +62,6 @@ class CoupleRepositoryImpl(
             remoteCoupleDataSource
                 .updateCoupleStartDate(
                     coupleId = coupleId,
-                    timeZone = TimeZone.currentSystemDefault().id,
                     request = request,
                 ).toCouple()
         }

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/datasource/RemoteCoupleDataSource.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/datasource/RemoteCoupleDataSource.kt
@@ -22,7 +22,6 @@ interface RemoteCoupleDataSource {
 
     suspend fun updateCoupleStartDate(
         coupleId: Long,
-        timeZone: String,
         request: CoupleStartDateUpdateRequest,
     ): CoupleBasicResponse
 

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/datasource/RemoteCoupleDatsSourceImpl.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/datasource/RemoteCoupleDatsSourceImpl.kt
@@ -7,11 +7,9 @@ import com.whatever.caramel.core.remote.dto.couple.response.CoupleAnniversaryRes
 import com.whatever.caramel.core.remote.dto.couple.response.CoupleBasicResponse
 import com.whatever.caramel.core.remote.dto.couple.response.CoupleDetailResponse
 import com.whatever.caramel.core.remote.dto.couple.response.CoupleInvitationCodeResponse
-import com.whatever.caramel.core.remote.network.config.Header
 import com.whatever.caramel.core.remote.network.util.getBody
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
-import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.patch
 import io.ktor.client.request.post
@@ -44,12 +42,10 @@ class RemoteCoupleDatsSourceImpl(
 
     override suspend fun updateCoupleStartDate(
         coupleId: Long,
-        timeZone: String,
         request: CoupleStartDateUpdateRequest,
     ): CoupleBasicResponse =
         authClient
             .patch(COUPLE_BASE_URL + "$coupleId/start-date") {
-                header(Header.TIME_ZONE, timeZone)
                 setBody(request)
             }.getBody()
 


### PR DESCRIPTION
## 관련 이슈
- [커플 기념일 - 시작일을 오늘로 설정하면 발생](https://www.notion.so/given-dragon/205870f222b9802ebc97da0c4ad18f77?d=335870f222b983b4be0c835701b39aa3)

## 작업한 내용
- RequestBuilder 내부 타임존 헤더 중복 제거