### PR TITLE
[Feat] 홈 - 오늘의 일정 아이템 담당자 컴포넌트 추가

### DIFF
--- a/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreviewData.kt
+++ b/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreviewData.kt
@@ -40,39 +40,42 @@ internal class HomeScreenPreviewData : PreviewParameterProvider<HomeState> {
             HomeState(
                 daysTogether = 1120,
                 shareMessage = "내일 여기서 만나",
-                todos = listOf(
-                    TodoState(
-                        id = 1,
-                        title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?",
-                        role = ContentRole.MY
-                    )
-                ),
+                todos =
+                    listOf(
+                        TodoState(
+                            id = 1,
+                            title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?",
+                            role = ContentRole.MY,
+                        ),
+                    ),
                 isShowBottomSheet = false,
                 isLoading = false,
             ),
             HomeState(
                 daysTogether = 1120,
                 shareMessage = "내일 여기서 만나",
-                todos = (0..7).map {
-                    TodoState(
-                        id = it.toLong(),
-                        title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?",
-                        role = ContentRole.BOTH
-                    )
-                },
+                todos =
+                    (0..7).map {
+                        TodoState(
+                            id = it.toLong(),
+                            title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?",
+                            role = ContentRole.BOTH,
+                        )
+                    },
                 isShowBottomSheet = false,
                 isLoading = false,
             ),
             HomeState(
                 daysTogether = 1120,
                 shareMessage = "내일 여기서 만나",
-                todos = (0..7).map {
-                    TodoState(
-                        id = it.toLong(),
-                        title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?",
-                        role = ContentRole.PARTNER
-                    )
-                },
+                todos =
+                    (0..7).map {
+                        TodoState(
+                            id = it.toLong(),
+                            title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?",
+                            role = ContentRole.PARTNER,
+                        )
+                    },
                 isShowBottomSheet = false,
                 isLoading = true,
             ),

--- a/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreviewData.kt
+++ b/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreviewData.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.home
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.whatever.caramel.core.domain.vo.content.ContentRole
 import com.whatever.caramel.feature.home.mvi.HomeState
 import com.whatever.caramel.feature.home.mvi.TodoState
 
@@ -39,21 +40,39 @@ internal class HomeScreenPreviewData : PreviewParameterProvider<HomeState> {
             HomeState(
                 daysTogether = 1120,
                 shareMessage = "내일 여기서 만나",
-                todos = listOf(TodoState(id = 1, title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?")),
+                todos = listOf(
+                    TodoState(
+                        id = 1,
+                        title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?",
+                        role = ContentRole.MY
+                    )
+                ),
                 isShowBottomSheet = false,
                 isLoading = false,
             ),
             HomeState(
                 daysTogether = 1120,
                 shareMessage = "내일 여기서 만나",
-                todos = (0..7).map { TodoState(it.toLong(), "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?") },
+                todos = (0..7).map {
+                    TodoState(
+                        id = it.toLong(),
+                        title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?",
+                        role = ContentRole.BOTH
+                    )
+                },
                 isShowBottomSheet = false,
                 isLoading = false,
             ),
             HomeState(
                 daysTogether = 1120,
                 shareMessage = "내일 여기서 만나",
-                todos = (0..7).map { TodoState(it.toLong(), "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?") },
+                todos = (0..7).map {
+                    TodoState(
+                        id = it.toLong(),
+                        title = "오늘 캘린더에 첫 번째로 적혀있는 것이 표시됩니다. 글자수가 넘어가면 어떻게 되나요?",
+                        role = ContentRole.PARTNER
+                    )
+                },
                 isShowBottomSheet = false,
                 isLoading = true,
             ),

--- a/feature/home/src/commonMain/composeResources/values/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values/strings.xml
@@ -15,6 +15,9 @@
 
 	<!-- Todo -->
 	<string name="start_couple_date_guid">커플 시작일을 입력해 주세요.\n기념일이 다가오면 알려드릴게요.</string>
+	<string name="my">나</string>
+	<string name="partner">연인</string>
+	<string name="both">우리</string>
 
 	<!-- UnConnectCard -->
 	<string name="unconnected_couple">연인과의 연결이 해제되었어요</string>

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeScreen.kt
@@ -27,10 +27,10 @@ import com.whatever.caramel.core.designsystem.components.DefaultCaramelDialogLay
 import com.whatever.caramel.core.designsystem.foundations.Resources
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
 import com.whatever.caramel.feature.home.components.ShareMessageBottomSheet
-import com.whatever.caramel.feature.home.components.disconnectedCard
-import com.whatever.caramel.feature.home.components.header
-import com.whatever.caramel.feature.home.components.quiz
-import com.whatever.caramel.feature.home.components.todo
+import com.whatever.caramel.feature.home.components.header.disconnectedCard
+import com.whatever.caramel.feature.home.components.header.header
+import com.whatever.caramel.feature.home.components.quiz.quiz
+import com.whatever.caramel.feature.home.components.todo.todo
 import com.whatever.caramel.feature.home.mvi.HomeIntent
 import com.whatever.caramel.feature.home.mvi.HomeState
 import kotlinx.collections.immutable.toImmutableList

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
@@ -10,6 +10,7 @@ import com.whatever.caramel.core.domain.usecase.balanceGame.SubmitBalanceGameCho
 import com.whatever.caramel.core.domain.usecase.calendar.GetTodayScheduleUseCase
 import com.whatever.caramel.core.domain.usecase.couple.GetCoupleRelationshipInfoUseCase
 import com.whatever.caramel.core.domain.usecase.couple.UpdateShareMessageUseCase
+import com.whatever.caramel.core.domain.vo.content.ContentRole
 import com.whatever.caramel.core.domain.vo.content.ContentType
 import com.whatever.caramel.core.domain.vo.user.Gender
 import com.whatever.caramel.core.ui.util.validateInputText
@@ -227,7 +228,13 @@ class HomeViewModel(
             copy(
                 todos =
                     if (schedules.isNotEmpty()) {
-                        schedules.map { todo -> TodoState(id = todo.id, title = todo.title.ifEmpty { todo.description }) }
+                        schedules.map { todo ->
+                            TodoState(
+                                id = todo.id,
+                                title = todo.title.ifEmpty { todo.description },
+                                role = ContentRole.MY // @ham2174 FIXME : 오늘의 일정 가져오기 로직 수정시 변경
+                            )
+                        }
                     } else {
                         emptyList()
                     },

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
@@ -232,7 +232,7 @@ class HomeViewModel(
                             TodoState(
                                 id = todo.id,
                                 title = todo.title.ifEmpty { todo.description },
-                                role = ContentRole.MY // @ham2174 FIXME : 오늘의 일정 가져오기 로직 수정시 변경
+                                role = ContentRole.MY, // @ham2174 FIXME : 오늘의 일정 가져오기 로직 수정시 변경
                             )
                         }
                     } else {

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Todos.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/Todos.kt
@@ -3,12 +3,14 @@ package com.whatever.caramel.feature.home.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -17,12 +19,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import caramel.feature.home.generated.resources.Res
+import caramel.feature.home.generated.resources.both
+import caramel.feature.home.generated.resources.my
+import caramel.feature.home.generated.resources.partner
 import caramel.feature.home.generated.resources.start_couple_date_guid
 import com.whatever.caramel.core.designsystem.foundations.Resources
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.core.domain.vo.content.ContentRole
 import com.whatever.caramel.feature.home.mvi.TodoState
 import kotlinx.collections.immutable.ImmutableList
 import org.jetbrains.compose.resources.DrawableResource
@@ -120,6 +127,7 @@ private fun TodoList(
                                 vertical = CaramelTheme.spacing.s,
                             ),
                     title = todo.title,
+                    role = todo.role,
                 )
 
                 if (index < todoList.size - 1) {
@@ -138,6 +146,7 @@ private fun TodoList(
 private fun TodoItem(
     modifier: Modifier = Modifier,
     title: String,
+    role: ContentRole,
 ) {
     Row(
         modifier = modifier,
@@ -147,14 +156,23 @@ private fun TodoItem(
             ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
+        Row(
             modifier = Modifier.weight(weight = 1f),
-            text = title,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            style = CaramelTheme.typography.body3.regular,
-            color = CaramelTheme.color.text.primary,
-        )
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(
+                space = CaramelTheme.spacing.s
+            ),
+        ) {
+            ContentRoleChip(role = role)
+
+            Text(
+                text = title,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = CaramelTheme.typography.body3.regular,
+                color = CaramelTheme.color.text.primary,
+            )
+        }
 
         Icon(
             painter = painterResource(resource = Resources.Icon.ic_arrow_right_16),
@@ -223,3 +241,56 @@ private fun NudgeCard(
         )
     }
 }
+
+@Composable
+private fun ContentRoleChip(
+    role: ContentRole
+) {
+    val chipBackgroundColor = when (role) {
+        ContentRole.NONE -> Color.Black
+        ContentRole.MY -> Color(0xFF009B08) // @ham2174 FIXME : 컬러 토큰 지정시 변경
+        ContentRole.PARTNER -> CaramelTheme.color.fill.secondary
+        ContentRole.BOTH -> CaramelTheme.color.fill.brand
+    }
+    val chipText = when (role) {
+        ContentRole.NONE -> ""
+        ContentRole.MY -> stringResource(resource = Res.string.my)
+        ContentRole.PARTNER -> stringResource(resource = Res.string.partner)
+        ContentRole.BOTH -> stringResource(resource = Res.string.both)
+    }
+
+    Box(
+        modifier = Modifier
+            .size(
+                width = 30.dp,
+                height = 20.dp
+            )
+            .background(
+                color = chipBackgroundColor,
+                shape = CaramelTheme.shape.xs
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = chipText,
+            style = CaramelTheme.typography.label2.bold,
+            color = CaramelTheme.color.text.inverse
+        )
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/header/DisconnectedCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/header/DisconnectedCard.kt
@@ -1,4 +1,4 @@
-package com.whatever.caramel.feature.home.components
+package com.whatever.caramel.feature.home.components.header
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/header/Header.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/header/Header.kt
@@ -1,4 +1,4 @@
-package com.whatever.caramel.feature.home.components
+package com.whatever.caramel.feature.home.components.header
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/quiz/BalanceGameResult.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/quiz/BalanceGameResult.kt
@@ -1,0 +1,97 @@
+package com.whatever.caramel.feature.home.components.quiz
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.whatever.caramel.core.designsystem.foundations.Resources
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.core.domain.vo.user.Gender
+import com.whatever.caramel.feature.home.mvi.BalanceGameOptionState
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+internal fun BalanceGameResult(
+    modifier: Modifier = Modifier,
+    myNickname: String,
+    myGender: Gender,
+    partnerNickname: String,
+    partnerGender: Gender,
+    myChoiceOption: BalanceGameOptionState,
+    partnerChoiceOption: BalanceGameOptionState,
+) {
+    val myGenderImage =
+        when (myGender) {
+            Gender.MALE -> Resources.Image.img_quiz_man
+            Gender.FEMALE -> Resources.Image.img_quiz_woman
+            else -> Resources.Image.img_quiz_man
+        }
+
+    val partnerGenderImage =
+        when (partnerGender) {
+            Gender.MALE -> Resources.Image.img_quiz_man
+            Gender.FEMALE -> Resources.Image.img_quiz_woman
+            else -> Resources.Image.img_quiz_man
+        }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement =
+            Arrangement.spacedBy(
+                space = CaramelTheme.spacing.l,
+                alignment = Alignment.CenterVertically,
+            ),
+    ) {
+        repeat(2) { index ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement =
+                    Arrangement.spacedBy(
+                        space = CaramelTheme.spacing.m,
+                    ),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Image(
+                    modifier = Modifier.size(size = 50.dp),
+                    painter =
+                        painterResource(
+                            resource =
+                                if (index == 0) {
+                                    myGenderImage
+                                } else {
+                                    partnerGenderImage
+                                },
+                        ),
+                    contentDescription = null,
+                )
+
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement =
+                        Arrangement.spacedBy(
+                            space = CaramelTheme.spacing.xxs,
+                        ),
+                ) {
+                    Text(
+                        text = if (index == 0) myNickname else partnerNickname,
+                        style = CaramelTheme.typography.body4.regular,
+                        color = CaramelTheme.color.text.secondary,
+                    )
+
+                    Text(
+                        text = if (index == 0) myChoiceOption.name else partnerChoiceOption.name,
+                        style = CaramelTheme.typography.body1.bold,
+                        color = CaramelTheme.color.text.primary,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/quiz/OptionButton.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/quiz/OptionButton.kt
@@ -1,0 +1,115 @@
+package com.whatever.caramel.feature.home.components.quiz
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.sp
+import com.whatever.caramel.core.designsystem.foundations.Resources
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.feature.home.mvi.HomeState
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+internal fun RowScope.OptionButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    isSelected: Boolean,
+    balanceGameAnswerState: HomeState.BalanceGameAnswerState,
+    onClick: () -> Unit,
+) {
+    val backgroundColor =
+        if (balanceGameAnswerState == HomeState.BalanceGameAnswerState.IDLE) {
+            CaramelTheme.color.fill.quinary
+        } else {
+            if (isSelected) {
+                CaramelTheme.color.fill.brand
+            } else {
+                CaramelTheme.color.fill.disabledPrimary
+            }
+        }
+
+    val textColor =
+        if (balanceGameAnswerState == HomeState.BalanceGameAnswerState.IDLE) {
+            CaramelTheme.color.text.brand
+        } else {
+            if (isSelected) {
+                CaramelTheme.color.text.inverse
+            } else {
+                CaramelTheme.color.text.disabledPrimary
+            }
+        }
+
+    Box(
+        modifier =
+            modifier
+                .weight(weight = 1f)
+                .fillMaxHeight()
+                .background(
+                    color = backgroundColor,
+                    shape = CaramelTheme.shape.m,
+                ).clip(shape = CaramelTheme.shape.m)
+                .clickable(
+                    enabled = balanceGameAnswerState != HomeState.BalanceGameAnswerState.WAITING,
+                    onClick = onClick,
+                ).padding(all = CaramelTheme.spacing.m),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (isSelected) {
+            val optionString =
+                buildAnnotatedString {
+                    appendInlineContent(id = "check icon")
+                    append(" ")
+                    append(text)
+                }
+            val inlineContentMap =
+                mapOf(
+                    "check icon" to
+                        InlineTextContent(
+                            placeholder =
+                                Placeholder(
+                                    width = 16.sp,
+                                    height = 16.sp,
+                                    placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
+                                ),
+                            children = {
+                                Icon(
+                                    painter = painterResource(resource = Resources.Icon.ic_check_16),
+                                    contentDescription = null,
+                                    tint = CaramelTheme.color.icon.inverse,
+                                )
+                            },
+                        ),
+                )
+
+            Text(
+                text = optionString,
+                inlineContent = inlineContentMap,
+                style = CaramelTheme.typography.body3.bold,
+                textAlign = TextAlign.Center,
+                color = textColor,
+            )
+        } else {
+            Text(
+                text = text,
+                style = CaramelTheme.typography.body3.bold,
+                textAlign = TextAlign.Center,
+                color = textColor,
+            )
+        }
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/quiz/Quiz.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/quiz/Quiz.kt
@@ -1,4 +1,4 @@
-package com.whatever.caramel.feature.home.components
+package com.whatever.caramel.feature.home.components.quiz
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
@@ -11,18 +11,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.text.InlineTextContent
-import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -33,12 +27,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.text.Placeholder
-import androidx.compose.ui.text.PlaceholderVerticalAlign
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import caramel.feature.home.generated.resources.Res
 import caramel.feature.home.generated.resources.check_choice_button
 import caramel.feature.home.generated.resources.check_our_choice
@@ -308,175 +298,6 @@ private fun ButtonArea(
                     style = CaramelTheme.typography.body3.bold,
                     color = CaramelTheme.color.text.inverse,
                 )
-            }
-        }
-    }
-}
-
-@Composable
-private fun RowScope.OptionButton(
-    modifier: Modifier = Modifier,
-    text: String,
-    isSelected: Boolean,
-    balanceGameAnswerState: HomeState.BalanceGameAnswerState,
-    onClick: () -> Unit,
-) {
-    val backgroundColor =
-        if (balanceGameAnswerState == HomeState.BalanceGameAnswerState.IDLE) {
-            CaramelTheme.color.fill.quinary
-        } else {
-            if (isSelected) {
-                CaramelTheme.color.fill.brand
-            } else {
-                CaramelTheme.color.fill.disabledPrimary
-            }
-        }
-
-    val textColor =
-        if (balanceGameAnswerState == HomeState.BalanceGameAnswerState.IDLE) {
-            CaramelTheme.color.text.brand
-        } else {
-            if (isSelected) {
-                CaramelTheme.color.text.inverse
-            } else {
-                CaramelTheme.color.text.disabledPrimary
-            }
-        }
-
-    Box(
-        modifier =
-            modifier
-                .weight(weight = 1f)
-                .fillMaxHeight()
-                .background(
-                    color = backgroundColor,
-                    shape = CaramelTheme.shape.m,
-                ).clip(shape = CaramelTheme.shape.m)
-                .clickable(
-                    enabled = balanceGameAnswerState != HomeState.BalanceGameAnswerState.WAITING,
-                    onClick = onClick,
-                ).padding(all = CaramelTheme.spacing.m),
-        contentAlignment = Alignment.Center,
-    ) {
-        if (isSelected) {
-            val optionString =
-                buildAnnotatedString {
-                    appendInlineContent(id = "check icon")
-                    append(" ")
-                    append(text)
-                }
-            val inlineContentMap =
-                mapOf(
-                    "check icon" to
-                        InlineTextContent(
-                            placeholder =
-                                Placeholder(
-                                    width = 16.sp,
-                                    height = 16.sp,
-                                    placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
-                                ),
-                            children = {
-                                Icon(
-                                    painter = painterResource(resource = Resources.Icon.ic_check_16),
-                                    contentDescription = null,
-                                    tint = CaramelTheme.color.icon.inverse,
-                                )
-                            },
-                        ),
-                )
-
-            Text(
-                text = optionString,
-                inlineContent = inlineContentMap,
-                style = CaramelTheme.typography.body3.bold,
-                textAlign = TextAlign.Center,
-                color = textColor,
-            )
-        } else {
-            Text(
-                text = text,
-                style = CaramelTheme.typography.body3.bold,
-                textAlign = TextAlign.Center,
-                color = textColor,
-            )
-        }
-    }
-}
-
-@Composable
-private fun BalanceGameResult(
-    modifier: Modifier = Modifier,
-    myNickname: String,
-    myGender: Gender,
-    partnerNickname: String,
-    partnerGender: Gender,
-    myChoiceOption: BalanceGameOptionState,
-    partnerChoiceOption: BalanceGameOptionState,
-) {
-    val myGenderImage =
-        when (myGender) {
-            Gender.MALE -> Resources.Image.img_quiz_man
-            Gender.FEMALE -> Resources.Image.img_quiz_woman
-            else -> Resources.Image.img_quiz_man
-        }
-
-    val partnerGenderImage =
-        when (partnerGender) {
-            Gender.MALE -> Resources.Image.img_quiz_man
-            Gender.FEMALE -> Resources.Image.img_quiz_woman
-            else -> Resources.Image.img_quiz_man
-        }
-
-    Column(
-        modifier = modifier,
-        verticalArrangement =
-            Arrangement.spacedBy(
-                space = CaramelTheme.spacing.l,
-                alignment = Alignment.CenterVertically,
-            ),
-    ) {
-        repeat(2) { index ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement =
-                    Arrangement.spacedBy(
-                        space = CaramelTheme.spacing.m,
-                    ),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Image(
-                    modifier = Modifier.size(size = 50.dp),
-                    painter =
-                        painterResource(
-                            resource =
-                                if (index == 0) {
-                                    myGenderImage
-                                } else {
-                                    partnerGenderImage
-                                },
-                        ),
-                    contentDescription = null,
-                )
-
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement =
-                        Arrangement.spacedBy(
-                            space = CaramelTheme.spacing.xxs,
-                        ),
-                ) {
-                    Text(
-                        text = if (index == 0) myNickname else partnerNickname,
-                        style = CaramelTheme.typography.body4.regular,
-                        color = CaramelTheme.color.text.secondary,
-                    )
-
-                    Text(
-                        text = if (index == 0) myChoiceOption.name else partnerChoiceOption.name,
-                        style = CaramelTheme.typography.body1.bold,
-                        color = CaramelTheme.color.text.primary,
-                    )
-                }
             }
         }
     }

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/todo/ContentRoleChip.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/todo/ContentRoleChip.kt
@@ -1,0 +1,55 @@
+package com.whatever.caramel.feature.home.components.todo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import caramel.feature.home.generated.resources.Res
+import caramel.feature.home.generated.resources.both
+import caramel.feature.home.generated.resources.my
+import caramel.feature.home.generated.resources.partner
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.core.domain.vo.content.ContentRole
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun ContentRoleChip(role: ContentRole) {
+    val chipBackgroundColor =
+        when (role) {
+            ContentRole.NONE -> Color.Black
+            ContentRole.MY -> Color(0xFF009B08) // @ham2174 FIXME : 컬러 토큰 지정시 변경
+            ContentRole.PARTNER -> CaramelTheme.color.fill.secondary
+            ContentRole.BOTH -> CaramelTheme.color.fill.brand
+        }
+    val chipText =
+        when (role) {
+            ContentRole.NONE -> ""
+            ContentRole.MY -> stringResource(resource = Res.string.my)
+            ContentRole.PARTNER -> stringResource(resource = Res.string.partner)
+            ContentRole.BOTH -> stringResource(resource = Res.string.both)
+        }
+
+    Box(
+        modifier =
+            Modifier
+                .size(
+                    width = 30.dp,
+                    height = 20.dp,
+                ).background(
+                    color = chipBackgroundColor,
+                    shape = CaramelTheme.shape.xs,
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = chipText,
+            style = CaramelTheme.typography.label2.bold,
+            color = CaramelTheme.color.text.inverse,
+        )
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/todo/EmptyTodo.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/todo/EmptyTodo.kt
@@ -1,0 +1,36 @@
+package com.whatever.caramel.feature.home.components.todo
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import com.whatever.caramel.core.designsystem.foundations.Resources
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+internal fun EmptyTodo(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "오늘 할 일을 등록해 주세요",
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = CaramelTheme.typography.body3.regular,
+            color = CaramelTheme.color.text.placeholder,
+        )
+
+        Icon(
+            painter = painterResource(resource = Resources.Icon.ic_plus_16),
+            tint = CaramelTheme.color.icon.tertiary,
+            contentDescription = null,
+        )
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/todo/NudgeCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/todo/NudgeCard.kt
@@ -1,0 +1,54 @@
+package com.whatever.caramel.feature.home.components.todo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+internal fun NudgeCard(
+    modifier: Modifier = Modifier,
+    text: String,
+    iconResource: DrawableResource,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(
+                    color = CaramelTheme.color.fill.quaternary,
+                    shape = CaramelTheme.shape.l,
+                ).clip(shape = CaramelTheme.shape.l)
+                .clickable(
+                    onClick = onClick,
+                    indication = null,
+                    interactionSource = null,
+                ).padding(all = CaramelTheme.spacing.l),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = text,
+            style = CaramelTheme.typography.body3.bold,
+            color = CaramelTheme.color.text.primary,
+        )
+
+        Icon(
+            painter = painterResource(resource = iconResource),
+            tint = CaramelTheme.color.icon.tertiary,
+            contentDescription = null,
+        )
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/todo/Todos.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/todo/Todos.kt
@@ -1,16 +1,14 @@
-package com.whatever.caramel.feature.home.components
+package com.whatever.caramel.feature.home.components.todo
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -18,21 +16,15 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import caramel.feature.home.generated.resources.Res
-import caramel.feature.home.generated.resources.both
-import caramel.feature.home.generated.resources.my
-import caramel.feature.home.generated.resources.partner
 import caramel.feature.home.generated.resources.start_couple_date_guid
 import com.whatever.caramel.core.designsystem.foundations.Resources
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
 import com.whatever.caramel.core.domain.vo.content.ContentRole
 import com.whatever.caramel.feature.home.mvi.TodoState
 import kotlinx.collections.immutable.ImmutableList
-import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -159,9 +151,10 @@ private fun TodoItem(
         Row(
             modifier = Modifier.weight(weight = 1f),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(
-                space = CaramelTheme.spacing.s
-            ),
+            horizontalArrangement =
+                Arrangement.spacedBy(
+                    space = CaramelTheme.spacing.s,
+                ),
         ) {
             ContentRoleChip(role = role)
 
@@ -181,116 +174,3 @@ private fun TodoItem(
         )
     }
 }
-
-@Composable
-private fun EmptyTodo(modifier: Modifier = Modifier) {
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = "오늘 할 일을 등록해 주세요",
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            style = CaramelTheme.typography.body3.regular,
-            color = CaramelTheme.color.text.placeholder,
-        )
-
-        Icon(
-            painter = painterResource(resource = Resources.Icon.ic_plus_16),
-            tint = CaramelTheme.color.icon.tertiary,
-            contentDescription = null,
-        )
-    }
-}
-
-@Composable
-private fun NudgeCard(
-    modifier: Modifier = Modifier,
-    text: String,
-    iconResource: DrawableResource,
-    onClick: () -> Unit,
-) {
-    Row(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .background(
-                    color = CaramelTheme.color.fill.quaternary,
-                    shape = CaramelTheme.shape.l,
-                ).clip(shape = CaramelTheme.shape.l)
-                .clickable(
-                    onClick = onClick,
-                    indication = null,
-                    interactionSource = null,
-                ).padding(all = CaramelTheme.spacing.l),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = text,
-            style = CaramelTheme.typography.body3.bold,
-            color = CaramelTheme.color.text.primary,
-        )
-
-        Icon(
-            painter = painterResource(resource = iconResource),
-            tint = CaramelTheme.color.icon.tertiary,
-            contentDescription = null,
-        )
-    }
-}
-
-@Composable
-private fun ContentRoleChip(
-    role: ContentRole
-) {
-    val chipBackgroundColor = when (role) {
-        ContentRole.NONE -> Color.Black
-        ContentRole.MY -> Color(0xFF009B08) // @ham2174 FIXME : 컬러 토큰 지정시 변경
-        ContentRole.PARTNER -> CaramelTheme.color.fill.secondary
-        ContentRole.BOTH -> CaramelTheme.color.fill.brand
-    }
-    val chipText = when (role) {
-        ContentRole.NONE -> ""
-        ContentRole.MY -> stringResource(resource = Res.string.my)
-        ContentRole.PARTNER -> stringResource(resource = Res.string.partner)
-        ContentRole.BOTH -> stringResource(resource = Res.string.both)
-    }
-
-    Box(
-        modifier = Modifier
-            .size(
-                width = 30.dp,
-                height = 20.dp
-            )
-            .background(
-                color = chipBackgroundColor,
-                shape = CaramelTheme.shape.xs
-            ),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = chipText,
-            style = CaramelTheme.typography.label2.bold,
-            color = CaramelTheme.color.text.inverse
-        )
-    }
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeState.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/mvi/HomeState.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.home.mvi
 
 import androidx.compose.runtime.Immutable
+import com.whatever.caramel.core.domain.vo.content.ContentRole
 import com.whatever.caramel.core.domain.vo.user.Gender
 import com.whatever.caramel.core.ui.util.codePointCount
 import com.whatever.caramel.core.viewmodel.UiState
@@ -70,6 +71,7 @@ data class HomeState(
 data class TodoState(
     val id: Long,
     val title: String,
+    val role: ContentRole,
 )
 
 data class BalanceGameState(


### PR DESCRIPTION
## 관련 이슈
- #288 

## 작업한 내용
- 오늘의 일정 아이템에 '담당자' 컴포넌트 추가

## PR 포인트
- 패키지 분류
  - 컴포넌트가 추가되면서 하나의 파일에서 관리가 힘들어 패키지로 분류했습니다.
    <img width="180" alt="image" src="https://github.com/user-attachments/assets/e35df6fe-2d74-412b-bbf1-778fedc30caf" />

## 미리보기
<img width="500" alt="image" src="https://github.com/user-attachments/assets/31136061-4433-4509-9997-142fa4f0d060" /><img width="250" alt="image" src="https://github.com/user-attachments/assets/74f4ecd5-2ea4-4c7e-8e1d-901c8fe57ae6" />

