### PR TITLE
[Feat] 캘린더 스케쥴 일정 담당자 UI 구현

### DIFF
--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/CalendarMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/CalendarMapper.kt
@@ -20,7 +20,7 @@ fun CalendarDetailResponse.toTodo(): List<Todo> =
             endDate = LocalDateTime.parse(it.endDateTime),
             title = it.title ?: "",
             description = it.description ?: "",
-            contentRole = ContentRole.MY // FIXME : API 연동 시 remote와 연결 필요
+            contentRole = ContentRole.MY, // FIXME : API 연동 시 remote와 연결 필요
         )
     }
 

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/themes/CaramelColor.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/themes/CaramelColor.kt
@@ -46,7 +46,7 @@ data class CaramelColor(
         val labelAccent1: Color = Red500,
         val labelAccent2: Color = Green600,
         val labelAccent3: Color = Neutral900,
-        val labelAccent4: Color = Green700
+        val labelAccent4: Color = Green700,
     )
 
     @Immutable
@@ -76,7 +76,7 @@ data class CaramelColor(
         val labelAccent1: Color = Red500,
         val labelAccent2: Color = Orange500,
         val labelAccent3: Color = Green200,
-        val labelAccent4: Color = Neutral300
+        val labelAccent4: Color = Neutral300,
     )
 
     @Immutable

--- a/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/themes/CaramelColor.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/whatever/caramel/core/designsystem/themes/CaramelColor.kt
@@ -3,7 +3,9 @@ package com.whatever.caramel.core.designsystem.themes
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import com.whatever.caramel.core.designsystem.foundations.Alpha100
+import com.whatever.caramel.core.designsystem.foundations.Green200
 import com.whatever.caramel.core.designsystem.foundations.Green600
+import com.whatever.caramel.core.designsystem.foundations.Green700
 import com.whatever.caramel.core.designsystem.foundations.Neutral100
 import com.whatever.caramel.core.designsystem.foundations.Neutral200
 import com.whatever.caramel.core.designsystem.foundations.Neutral300
@@ -43,6 +45,8 @@ data class CaramelColor(
         val labelBrand: Color = Orange700,
         val labelAccent1: Color = Red500,
         val labelAccent2: Color = Green600,
+        val labelAccent3: Color = Neutral900,
+        val labelAccent4: Color = Green700
     )
 
     @Immutable
@@ -71,6 +75,8 @@ data class CaramelColor(
         val labelBrand: Color = Orange300,
         val labelAccent1: Color = Red500,
         val labelAccent2: Color = Orange500,
+        val labelAccent3: Color = Green200,
+        val labelAccent4: Color = Neutral300
     )
 
     @Immutable

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Todo.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Todo.kt
@@ -9,7 +9,7 @@ data class Todo(
     val endDate: LocalDateTime,
     val title: String,
     val description: String,
-    val contentRole: ContentRole
+    val contentRole: ContentRole,
 ) {
     val url: String?
         get() {

--- a/feature/calendar/src/androidMain/kotlin/com/whatever/caramel/feature/calendar/component/CalendarScreenPreview.kt
+++ b/feature/calendar/src/androidMain/kotlin/com/whatever/caramel/feature/calendar/component/CalendarScreenPreview.kt
@@ -10,12 +10,12 @@ import com.whatever.caramel.feature.calendar.mvi.CalendarState
 @Composable
 @Preview
 private fun CalendarScreenPreview(
-    @PreviewParameter(CalendarScreenPreviewData::class) state : CalendarState
+    @PreviewParameter(CalendarScreenPreviewData::class) state: CalendarState,
 ) {
     CaramelTheme {
         CalendarScreen(
             state = state,
-            onIntent = {}
+            onIntent = {},
         )
     }
 }

--- a/feature/calendar/src/androidMain/kotlin/com/whatever/caramel/feature/calendar/component/CalendarScreenPreview.kt
+++ b/feature/calendar/src/androidMain/kotlin/com/whatever/caramel/feature/calendar/component/CalendarScreenPreview.kt
@@ -1,0 +1,21 @@
+package com.whatever.caramel.feature.calendar.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.feature.calendar.CalendarScreen
+import com.whatever.caramel.feature.calendar.mvi.CalendarState
+
+@Composable
+@Preview
+private fun CalendarScreenPreview(
+    @PreviewParameter(CalendarScreenPreviewData::class) state : CalendarState
+) {
+    CaramelTheme {
+        CalendarScreen(
+            state = state,
+            onIntent = {}
+        )
+    }
+}

--- a/feature/calendar/src/androidMain/kotlin/com/whatever/caramel/feature/calendar/component/CalendarScreenPreviewData.kt
+++ b/feature/calendar/src/androidMain/kotlin/com/whatever/caramel/feature/calendar/component/CalendarScreenPreviewData.kt
@@ -17,52 +17,69 @@ import kotlinx.datetime.Month
 import kotlinx.datetime.number
 
 internal class CalendarScreenPreviewData : PreviewParameterProvider<CalendarState> {
-
     private val year = 2025
     private val month = Month.JULY
 
     override val values: Sequence<CalendarState>
-        get() = sequenceOf(
-            CalendarState(
-                year, month, currentDates(), pageIndex(),
-                isShowDatePicker = false,
-                bottomSheetState = BottomSheetState.PARTIALLY_EXPANDED,
-                yearSchedule = yearSchedule(),
-            ),
-            CalendarState(
-                year, month, currentDates(), pageIndex(),
-                isShowDatePicker = true,
-                bottomSheetState = BottomSheetState.PARTIALLY_EXPANDED,
-                yearSchedule = yearSchedule(),
-            ),
-            CalendarState(
-                year, month, currentDates(), pageIndex(),
-                isShowDatePicker = false,
-                bottomSheetState = BottomSheetState.EXPANDED,
-                yearSchedule = yearSchedule(),
+        get() =
+            sequenceOf(
+                CalendarState(
+                    year,
+                    month,
+                    currentDates(),
+                    pageIndex(),
+                    isShowDatePicker = false,
+                    bottomSheetState = BottomSheetState.PARTIALLY_EXPANDED,
+                    yearSchedule = yearSchedule(),
+                ),
+                CalendarState(
+                    year,
+                    month,
+                    currentDates(),
+                    pageIndex(),
+                    isShowDatePicker = true,
+                    bottomSheetState = BottomSheetState.PARTIALLY_EXPANDED,
+                    yearSchedule = yearSchedule(),
+                ),
+                CalendarState(
+                    year,
+                    month,
+                    currentDates(),
+                    pageIndex(),
+                    isShowDatePicker = false,
+                    bottomSheetState = BottomSheetState.EXPANDED,
+                    yearSchedule = yearSchedule(),
+                ),
             )
-        )
 
     private fun currentDates(): List<LocalDate> =
         (1..DateUtil.getLastDayOfMonth(year, month.number))
             .map { LocalDate(year, month, it) }
 
-    private fun pageIndex(): Int =
-        Calendar.YEAR_RANGE.indexOf(year) * 12 + (month.number - 1)
+    private fun pageIndex(): Int = Calendar.YEAR_RANGE.indexOf(year) * 12 + (month.number - 1)
 
     private fun date(day: Int) = LocalDate(year, month, day)
-    private fun dateTime(day: Int, hour: Int = 0, minute: Int = 0) =
-        LocalDateTime(year, month, day, hour, minute)
+
+    private fun dateTime(
+        day: Int,
+        hour: Int = 0,
+        minute: Int = 0,
+    ) = LocalDateTime(year, month, day, hour, minute)
 
     private fun yearSchedule(): List<DaySchedule> {
         var id = 1L
-        fun todo(day: Int, title: String, role: ContentRole) = Todo(
+
+        fun todo(
+            day: Int,
+            title: String,
+            role: ContentRole,
+        ) = Todo(
             id = id++,
             title = title,
             startDate = dateTime(day),
             endDate = dateTime(day, 23, 59),
             description = "$title 내용",
-            contentRole = role
+            contentRole = role,
         )
 
         return listOf(
@@ -71,21 +88,23 @@ internal class CalendarScreenPreviewData : PreviewParameterProvider<CalendarStat
             DaySchedule(date = date(3), todos = listOf(todo(3, "상대 일정", ContentRole.PARTNER))),
             DaySchedule(
                 date = date(4),
-                holidays = listOf(
-                    Holiday(id = id++, date = date(4), name = "휴일", isHoliday = true)
-                )
+                holidays =
+                    listOf(
+                        Holiday(id = id++, date = date(4), name = "휴일", isHoliday = true),
+                    ),
             ),
             DaySchedule(
                 date = date(5),
-                anniversaries = listOf(
-                    Anniversary(
-                        type = AnniversaryType.BIRTHDAY,
-                        date = date(5),
-                        label = "생일",
-                        isAdjustedForNonLeapYear = false
-                    )
-                )
-            )
+                anniversaries =
+                    listOf(
+                        Anniversary(
+                            type = AnniversaryType.BIRTHDAY,
+                            date = date(5),
+                            label = "생일",
+                            isAdjustedForNonLeapYear = false,
+                        ),
+                    ),
+            ),
         )
     }
 }

--- a/feature/calendar/src/androidMain/kotlin/com/whatever/caramel/feature/calendar/component/CalendarScreenPreviewData.kt
+++ b/feature/calendar/src/androidMain/kotlin/com/whatever/caramel/feature/calendar/component/CalendarScreenPreviewData.kt
@@ -1,0 +1,91 @@
+package com.whatever.caramel.feature.calendar.component
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.whatever.caramel.core.domain.entity.Holiday
+import com.whatever.caramel.core.domain.entity.Todo
+import com.whatever.caramel.core.domain.vo.calendar.Calendar
+import com.whatever.caramel.core.domain.vo.content.ContentRole
+import com.whatever.caramel.core.domain.vo.couple.Anniversary
+import com.whatever.caramel.core.domain.vo.couple.AnniversaryType
+import com.whatever.caramel.core.util.DateUtil
+import com.whatever.caramel.feature.calendar.mvi.BottomSheetState
+import com.whatever.caramel.feature.calendar.mvi.CalendarState
+import com.whatever.caramel.feature.calendar.mvi.DaySchedule
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Month
+import kotlinx.datetime.number
+
+internal class CalendarScreenPreviewData : PreviewParameterProvider<CalendarState> {
+
+    private val year = 2025
+    private val month = Month.JULY
+
+    override val values: Sequence<CalendarState>
+        get() = sequenceOf(
+            CalendarState(
+                year, month, currentDates(), pageIndex(),
+                isShowDatePicker = false,
+                bottomSheetState = BottomSheetState.PARTIALLY_EXPANDED,
+                yearSchedule = yearSchedule(),
+            ),
+            CalendarState(
+                year, month, currentDates(), pageIndex(),
+                isShowDatePicker = true,
+                bottomSheetState = BottomSheetState.PARTIALLY_EXPANDED,
+                yearSchedule = yearSchedule(),
+            ),
+            CalendarState(
+                year, month, currentDates(), pageIndex(),
+                isShowDatePicker = false,
+                bottomSheetState = BottomSheetState.EXPANDED,
+                yearSchedule = yearSchedule(),
+            )
+        )
+
+    private fun currentDates(): List<LocalDate> =
+        (1..DateUtil.getLastDayOfMonth(year, month.number))
+            .map { LocalDate(year, month, it) }
+
+    private fun pageIndex(): Int =
+        Calendar.YEAR_RANGE.indexOf(year) * 12 + (month.number - 1)
+
+    private fun date(day: Int) = LocalDate(year, month, day)
+    private fun dateTime(day: Int, hour: Int = 0, minute: Int = 0) =
+        LocalDateTime(year, month, day, hour, minute)
+
+    private fun yearSchedule(): List<DaySchedule> {
+        var id = 1L
+        fun todo(day: Int, title: String, role: ContentRole) = Todo(
+            id = id++,
+            title = title,
+            startDate = dateTime(day),
+            endDate = dateTime(day, 23, 59),
+            description = "$title 내용",
+            contentRole = role
+        )
+
+        return listOf(
+            DaySchedule(date = date(1), todos = listOf(todo(1, "내 일정", ContentRole.MY))),
+            DaySchedule(date = date(2), todos = listOf(todo(2, "커플 일정", ContentRole.BOTH))),
+            DaySchedule(date = date(3), todos = listOf(todo(3, "상대 일정", ContentRole.PARTNER))),
+            DaySchedule(
+                date = date(4),
+                holidays = listOf(
+                    Holiday(id = id++, date = date(4), name = "휴일", isHoliday = true)
+                )
+            ),
+            DaySchedule(
+                date = date(5),
+                anniversaries = listOf(
+                    Anniversary(
+                        type = AnniversaryType.BIRTHDAY,
+                        date = date(5),
+                        label = "생일",
+                        isAdjustedForNonLeapYear = false
+                    )
+                )
+            )
+        )
+    }
+}

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/component/calendar/Schedule.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/component/calendar/Schedule.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalDensity
@@ -15,6 +16,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
 import com.whatever.caramel.core.domain.entity.Holiday
 import com.whatever.caramel.core.domain.entity.Todo
+import com.whatever.caramel.core.domain.vo.content.ContentRole
 import com.whatever.caramel.core.domain.vo.couple.Anniversary
 import com.whatever.caramel.feature.calendar.mvi.DaySchedule
 
@@ -118,23 +120,44 @@ fun CalendarScheduleList(
 }
 
 @Composable
-private fun CalendarAnniversaryItem(
+private fun ScheduleItem(
     modifier: Modifier = Modifier,
-    anniversary: Anniversary,
+    content: String,
+    backgroundColor: Color,
+    textColor: Color,
+    onClick: () -> Unit = {}
 ) {
     Text(
         modifier =
             modifier
                 .fillMaxWidth()
                 .background(
-                    color = CaramelTheme.color.fill.brand,
+                    color = backgroundColor,
                     shape = CaramelTheme.shape.xxs,
-                ).padding(horizontal = CaramelTheme.spacing.xxs),
+                ).padding(horizontal = CaramelTheme.spacing.xxs)
+                .clickable(
+                    indication = null,
+                    interactionSource = null,
+                    onClick = onClick
+                ),
         maxLines = 1,
         overflow = TextOverflow.Clip,
-        text = anniversary.label,
+        text = content,
         style = CaramelTheme.typography.label3.bold,
-        color = CaramelTheme.color.text.inverse,
+        color = textColor,
+    )
+}
+
+@Composable
+private fun CalendarAnniversaryItem(
+    modifier: Modifier = Modifier,
+    anniversary: Anniversary,
+) {
+    ScheduleItem(
+        modifier = modifier,
+        content = anniversary.label,
+        backgroundColor = CaramelTheme.color.fill.brand,
+        textColor = CaramelTheme.color.text.inverse
     )
 }
 
@@ -143,19 +166,11 @@ private fun CalendarHolidayItem(
     modifier: Modifier = Modifier,
     holiday: Holiday,
 ) {
-    Text(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .background(
-                    color = CaramelTheme.color.fill.labelAccent1,
-                    shape = CaramelTheme.shape.xxs,
-                ).padding(horizontal = CaramelTheme.spacing.xxs),
-        maxLines = 1,
-        overflow = TextOverflow.Clip,
-        text = holiday.name,
-        style = CaramelTheme.typography.label3.bold,
-        color = CaramelTheme.color.text.inverse,
+    ScheduleItem(
+        modifier = modifier,
+        content = holiday.name,
+        backgroundColor = CaramelTheme.color.fill.labelAccent1,
+        textColor = CaramelTheme.color.text.inverse
     )
 }
 
@@ -165,23 +180,12 @@ private fun CalendarTodoItem(
     todo: Todo,
     onClickTodo: (Long) -> Unit,
 ) {
-    Text(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .background(
-                    color = CaramelTheme.color.fill.labelBrand,
-                    shape = CaramelTheme.shape.xxs,
-                ).padding(horizontal = CaramelTheme.spacing.xxs)
-                .clickable(
-                    interactionSource = null,
-                    indication = null,
-                    onClick = { onClickTodo(todo.id) },
-                ),
-        maxLines = 1,
-        overflow = TextOverflow.Clip,
-        text = todo.title.ifEmpty { todo.description },
-        style = CaramelTheme.typography.label3.bold,
-        color = CaramelTheme.color.text.labelBrand,
+
+    ScheduleItem(
+        modifier = modifier,
+        content = todo.title.ifEmpty { todo.description },
+        backgroundColor = backgroundColor,
+        textColor = textColor,
+        onClick = { onClickTodo(todo.id) }
     )
 }

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/component/calendar/Schedule.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/component/calendar/Schedule.kt
@@ -180,6 +180,11 @@ private fun CalendarTodoItem(
     todo: Todo,
     onClickTodo: (Long) -> Unit,
 ) {
+    val (textColor, backgroundColor) = when (todo.contentRole) {
+        ContentRole.MY -> CaramelTheme.color.text.labelAccent4 to CaramelTheme.color.fill.labelAccent3
+        ContentRole.PARTNER -> CaramelTheme.color.text.labelAccent3 to CaramelTheme.color.fill.labelAccent4
+        ContentRole.NONE, ContentRole.BOTH -> CaramelTheme.color.text.labelBrand to CaramelTheme.color.fill.labelBrand
+    }
 
     ScheduleItem(
         modifier = modifier,

--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/component/calendar/Schedule.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/component/calendar/Schedule.kt
@@ -125,7 +125,7 @@ private fun ScheduleItem(
     content: String,
     backgroundColor: Color,
     textColor: Color,
-    onClick: () -> Unit = {}
+    onClick: () -> Unit = {},
 ) {
     Text(
         modifier =
@@ -138,7 +138,7 @@ private fun ScheduleItem(
                 .clickable(
                     indication = null,
                     interactionSource = null,
-                    onClick = onClick
+                    onClick = onClick,
                 ),
         maxLines = 1,
         overflow = TextOverflow.Clip,
@@ -157,7 +157,7 @@ private fun CalendarAnniversaryItem(
         modifier = modifier,
         content = anniversary.label,
         backgroundColor = CaramelTheme.color.fill.brand,
-        textColor = CaramelTheme.color.text.inverse
+        textColor = CaramelTheme.color.text.inverse,
     )
 }
 
@@ -170,7 +170,7 @@ private fun CalendarHolidayItem(
         modifier = modifier,
         content = holiday.name,
         backgroundColor = CaramelTheme.color.fill.labelAccent1,
-        textColor = CaramelTheme.color.text.inverse
+        textColor = CaramelTheme.color.text.inverse,
     )
 }
 
@@ -180,17 +180,18 @@ private fun CalendarTodoItem(
     todo: Todo,
     onClickTodo: (Long) -> Unit,
 ) {
-    val (textColor, backgroundColor) = when (todo.contentRole) {
-        ContentRole.MY -> CaramelTheme.color.text.labelAccent4 to CaramelTheme.color.fill.labelAccent3
-        ContentRole.PARTNER -> CaramelTheme.color.text.labelAccent3 to CaramelTheme.color.fill.labelAccent4
-        ContentRole.NONE, ContentRole.BOTH -> CaramelTheme.color.text.labelBrand to CaramelTheme.color.fill.labelBrand
-    }
+    val (textColor, backgroundColor) =
+        when (todo.contentRole) {
+            ContentRole.MY -> CaramelTheme.color.text.labelAccent4 to CaramelTheme.color.fill.labelAccent3
+            ContentRole.PARTNER -> CaramelTheme.color.text.labelAccent3 to CaramelTheme.color.fill.labelAccent4
+            ContentRole.NONE, ContentRole.BOTH -> CaramelTheme.color.text.labelBrand to CaramelTheme.color.fill.labelBrand
+        }
 
     ScheduleItem(
         modifier = modifier,
         content = todo.title.ifEmpty { todo.description },
         backgroundColor = backgroundColor,
         textColor = textColor,
-        onClick = { onClickTodo(todo.id) }
+        onClick = { onClickTodo(todo.id) },
     )
 }


### PR DESCRIPTION
## 관련 이슈
- #273 

## 작업한 내용
<img width="391" height="210" alt="image" src="https://github.com/user-attachments/assets/f7bd7c7e-1cdf-46b8-aecf-a834874c872e" />

- 캘린더 셀의 일정 담당자 구현
- 디자인 색상 추가
- 캘린더 프리뷰 구현

## PR 포인트
- 기존 캘린더에 표시되던 셀 UI를 1개의 컴포저블로 가져가고 일정/휴일/기념일로 나눴습니다.
```
@Composable
private fun ScheduleItem(
    modifier: Modifier = Modifier,
    content: String,
    backgroundColor: Color,
    textColor: Color,
    onClick: () -> Unit = {}
) {
    Text(
        modifier =
            modifier
                .fillMaxWidth()
                .background(
                    color = backgroundColor,
                    shape = CaramelTheme.shape.xxs,
                ).padding(horizontal = CaramelTheme.spacing.xxs)
                .clickable(
                    indication = null,
                    interactionSource = null,
                    onClick = onClick
                ),
        maxLines = 1,
        overflow = TextOverflow.Clip,
        text = content,
        style = CaramelTheme.typography.label3.bold,
        color = textColor,
    )
}
```