### PR TITLE
[Feat] 메모 담당자 UI 구현

### DIFF
--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/ContentMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/ContentMapper.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.core.data.mapper
 
 import com.whatever.caramel.core.domain.entity.Memo
+import com.whatever.caramel.core.domain.vo.content.ContentRole
 import com.whatever.caramel.core.domain.vo.memo.MemoMetadata
 import com.whatever.caramel.core.domain.vo.memo.MemoWithCursor
 import com.whatever.caramel.core.remote.dto.memo.response.CreateMemoResponse
@@ -22,6 +23,7 @@ internal fun MemoResponse.toMemo(): Memo =
         isCompleted = this.isCompleted,
         tagList = this.tagList.toTags(),
         createdAt = LocalDate.parse(this.createdAt),
+        role = ContentRole.BOTH // FIXME : API 연동 작업 시 변경
     )
 
 internal fun CursoredContentResponse.toMemosWithCursor(): MemoWithCursor =

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/ContentMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/ContentMapper.kt
@@ -23,7 +23,7 @@ internal fun MemoResponse.toMemo(): Memo =
         isCompleted = this.isCompleted,
         tagList = this.tagList.toTags(),
         createdAt = LocalDate.parse(this.createdAt),
-        role = ContentRole.BOTH // FIXME : API 연동 작업 시 변경
+        role = ContentRole.BOTH, // FIXME : API 연동 작업 시 변경
     )
 
 internal fun CursoredContentResponse.toMemosWithCursor(): MemoWithCursor =

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Memo.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Memo.kt
@@ -10,5 +10,5 @@ data class Memo(
     val isCompleted: Boolean,
     val tagList: List<Tag>,
     val createdAt: LocalDate,
-    val role : ContentRole
+    val role: ContentRole,
 )

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Memo.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Memo.kt
@@ -1,5 +1,6 @@
 package com.whatever.caramel.core.domain.entity
 
+import com.whatever.caramel.core.domain.vo.content.ContentRole
 import kotlinx.datetime.LocalDate
 
 data class Memo(
@@ -9,4 +10,5 @@ data class Memo(
     val isCompleted: Boolean,
     val tagList: List<Tag>,
     val createdAt: LocalDate,
+    val role : ContentRole
 )

--- a/feature/memo/src/androidMain/kotlin/com/whatever/caramel/feature/memo/component/MemoScreenPreviewProvider.kt
+++ b/feature/memo/src/androidMain/kotlin/com/whatever/caramel/feature/memo/component/MemoScreenPreviewProvider.kt
@@ -3,9 +3,12 @@ package com.whatever.caramel.feature.memo.component
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.whatever.caramel.core.domain.entity.Memo
 import com.whatever.caramel.core.domain.entity.Tag
+import com.whatever.caramel.core.domain.vo.content.ContentRole
 import com.whatever.caramel.core.util.DateUtil
+import com.whatever.caramel.feature.memo.model.MemoUiModel
+import com.whatever.caramel.feature.memo.model.TagUiModel
+import com.whatever.caramel.feature.memo.model.toUiModel
 import com.whatever.caramel.feature.memo.mvi.MemoState
-import com.whatever.caramel.feature.memo.mvi.TagUiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -37,7 +40,7 @@ internal class MemoScreenPreviewProvider : PreviewParameterProvider<MemoState> {
     private fun createTempMemoList(
         size: Int,
         emptyTitle: Boolean = false,
-    ): ImmutableList<Memo> {
+    ): ImmutableList<MemoUiModel> {
         val list = mutableListOf<Memo>()
         for (index in 0 until size) {
             list.add(
@@ -48,10 +51,11 @@ internal class MemoScreenPreviewProvider : PreviewParameterProvider<MemoState> {
                     isCompleted = false,
                     tagList = createTempTagList(index),
                     createdAt = DateUtil.today(),
+                    role = ContentRole.BOTH,
                 ),
             )
         }
-        return list.toImmutableList()
+        return list.map { it.toUiModel() }.toImmutableList()
     }
 
     private fun createTempTagList(size: Int): ImmutableList<Tag> {

--- a/feature/memo/src/androidMain/kotlin/com/whatever/caramel/feature/memo/component/MemoScreenPreviewProvider.kt
+++ b/feature/memo/src/androidMain/kotlin/com/whatever/caramel/feature/memo/component/MemoScreenPreviewProvider.kt
@@ -43,6 +43,12 @@ internal class MemoScreenPreviewProvider : PreviewParameterProvider<MemoState> {
     ): ImmutableList<MemoUiModel> {
         val list = mutableListOf<Memo>()
         for (index in 0 until size) {
+            val role =
+                when {
+                    index % 2 == 0 -> ContentRole.BOTH
+                    index % 3 == 0 -> ContentRole.PARTNER
+                    else -> ContentRole.MY
+                }
             list.add(
                 Memo(
                     id = index.toLong(),
@@ -51,7 +57,7 @@ internal class MemoScreenPreviewProvider : PreviewParameterProvider<MemoState> {
                     isCompleted = false,
                     tagList = createTempTagList(index),
                     createdAt = DateUtil.today(),
-                    role = ContentRole.BOTH,
+                    role = role,
                 ),
             )
         }

--- a/feature/memo/src/commonMain/composeResources/values/strings.xml
+++ b/feature/memo/src/commonMain/composeResources/values/strings.xml
@@ -3,4 +3,8 @@
 	<string name="empty_memo">남긴 메모가 없어요.\n함께하고 싶은 활동이나\n기억하고 싶은 것들을 남겨보세요.</string>
 	<string name="memo">메모</string>
 	<string name="tag_all">전체</string>
+
+	<string name="my_memo">나의 메모</string>
+	<string name="partner_memo">연인의 메모</string>
+	<string name="both_memo">우리의 메모</string>
 </resources>

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoScreen.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoScreen.kt
@@ -34,7 +34,6 @@ import caramel.feature.memo.generated.resources.memo
 import com.whatever.caramel.core.designsystem.animation.animateScrollToItemCenter
 import com.whatever.caramel.core.designsystem.components.CaramelPullToRefreshIndicator
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
-import com.whatever.caramel.core.util.DateFormatter.formatWithSeparator
 import com.whatever.caramel.feature.memo.component.EmptyMemo
 import com.whatever.caramel.feature.memo.component.MemoItem
 import com.whatever.caramel.feature.memo.component.MemoItemSkeleton
@@ -165,9 +164,10 @@ internal fun MemoScreen(
                                 id = memo.id,
                                 title = memo.title,
                                 description = memo.description,
-                                categoriesText = memo.tagList.joinToString(separator = ",") { it.label },
-                                createdDateText = memo.createdAt.formatWithSeparator(separator = "."),
+                                categoriesText = memo.tagListText,
+                                createdDateText = memo.createdAt,
                                 onClickMemoItem = { onIntent(MemoIntent.ClickMemo(memoId = it)) },
+                                role = memo.role,
                             )
                             if (index < state.memos.lastIndex) {
                                 HorizontalDivider(

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoViewModel.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoViewModel.kt
@@ -8,10 +8,11 @@ import com.whatever.caramel.core.domain.usecase.content.GetMemosUseCase
 import com.whatever.caramel.core.domain.usecase.tag.GetTagUseCase
 import com.whatever.caramel.core.domain.vo.content.ContentType
 import com.whatever.caramel.core.viewmodel.BaseViewModel
+import com.whatever.caramel.feature.memo.model.TagUiModel
+import com.whatever.caramel.feature.memo.model.toUiModel
 import com.whatever.caramel.feature.memo.mvi.MemoIntent
 import com.whatever.caramel.feature.memo.mvi.MemoSideEffect
 import com.whatever.caramel.feature.memo.mvi.MemoState
-import com.whatever.caramel.feature.memo.mvi.TagUiModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
@@ -152,7 +153,7 @@ class MemoViewModel(
                 if (newMemos.memos.isEmpty()) {
                     currentState.memos
                 } else {
-                    currentState.memos + newMemos.memos
+                    currentState.memos + newMemos.memos.map { it.toUiModel() }
                 }
             reduce {
                 copy(

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/MemoItem.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/MemoItem.kt
@@ -23,9 +23,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import caramel.feature.memo.generated.resources.Res
+import caramel.feature.memo.generated.resources.both_memo
 import caramel.feature.memo.generated.resources.empty_memo
+import caramel.feature.memo.generated.resources.my_memo
+import caramel.feature.memo.generated.resources.partner_memo
 import com.whatever.caramel.core.designsystem.foundations.Resources
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.core.domain.vo.content.ContentRole
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -39,6 +43,7 @@ internal fun MemoItem(
     description: String,
     categoriesText: String,
     createdDateText: String,
+    role: ContentRole,
     onClickMemoItem: (Long) -> Unit,
 ) {
     val isTitleOrDescriptionEmpty = title.isEmpty() || description.isEmpty()
@@ -74,32 +79,65 @@ internal fun MemoItem(
                 color = CaramelTheme.color.text.primary,
             )
         }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(space = CaramelTheme.spacing.xs),
-        ) {
+        TabMetaData(
+            role = role,
+            createdDateText = createdDateText,
+            categoriesText = categoriesText,
+        )
+    }
+}
+
+@Composable
+internal fun TabMetaData(
+    role: ContentRole,
+    createdDateText: String,
+    categoriesText: String,
+) {
+    val memoText =
+        stringResource(
+            when (role) {
+                ContentRole.MY -> Res.string.my_memo
+                ContentRole.PARTNER -> Res.string.partner_memo
+                ContentRole.NONE, ContentRole.BOTH -> Res.string.both_memo
+            },
+        )
+
+    @Composable
+    fun Dot() {
+        Box(
+            modifier =
+                Modifier
+                    .size(size = 2.dp)
+                    .clip(CircleShape)
+                    .background(color = CaramelTheme.color.text.secondary),
+        )
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(space = CaramelTheme.spacing.xs),
+    ) {
+        Text(
+            text = memoText,
+            style = CaramelTheme.typography.label1.regular,
+            color = CaramelTheme.color.text.secondary,
+        )
+        Dot()
+        Text(
+            text = createdDateText,
+            style = CaramelTheme.typography.label1.regular,
+            color = CaramelTheme.color.text.secondary,
+        )
+        if (categoriesText.isNotEmpty()) {
+            Dot()
             Text(
-                text = createdDateText,
+                text = categoriesText,
+                maxLines = 1,
                 style = CaramelTheme.typography.label1.regular,
                 color = CaramelTheme.color.text.secondary,
+                overflow = TextOverflow.Ellipsis,
             )
-            if (categoriesText.isNotEmpty()) {
-                Box(
-                    modifier =
-                        Modifier
-                            .size(size = 2.dp)
-                            .clip(CircleShape)
-                            .background(color = CaramelTheme.color.text.secondary),
-                )
-                Text(
-                    text = categoriesText,
-                    maxLines = 1,
-                    style = CaramelTheme.typography.label1.regular,
-                    color = CaramelTheme.color.text.secondary,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
         }
     }
 }

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/TagItem.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/TagItem.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 import caramel.feature.memo.generated.resources.Res
 import caramel.feature.memo.generated.resources.tag_all
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
-import com.whatever.caramel.feature.memo.mvi.TagUiModel
+import com.whatever.caramel.feature.memo.model.TagUiModel
 import org.jetbrains.compose.resources.stringResource
 
 @Composable

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/model/MemoUiModel.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/model/MemoUiModel.kt
@@ -6,6 +6,7 @@ import com.whatever.caramel.core.domain.entity.Tag
 import com.whatever.caramel.core.domain.vo.content.ContentRole
 import com.whatever.caramel.core.util.DateFormatter.formatWithSeparator
 
+@Immutable
 data class MemoUiModel(
     val id: Long,
     val title: String,

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/model/MemoUiModel.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/model/MemoUiModel.kt
@@ -1,0 +1,42 @@
+package com.whatever.caramel.feature.memo.model
+
+import androidx.compose.runtime.Immutable
+import com.whatever.caramel.core.domain.entity.Memo
+import com.whatever.caramel.core.domain.entity.Tag
+import com.whatever.caramel.core.domain.vo.content.ContentRole
+import com.whatever.caramel.core.util.DateFormatter.formatWithSeparator
+
+data class MemoUiModel(
+    val id: Long,
+    val title: String,
+    val description: String,
+    val isCompleted: Boolean,
+    val tagListText: String,
+    val createdAt: String,
+    val role: ContentRole,
+)
+
+fun Memo.toUiModel() =
+    MemoUiModel(
+        id = this.id,
+        title = this.title,
+        description = this.description,
+        isCompleted = this.isCompleted,
+        tagListText = this.tagList.joinToString(separator = ",") { it.label },
+        createdAt = this.createdAt.formatWithSeparator(separator = "."),
+        role = this.role,
+    )
+
+@Immutable
+data class TagUiModel(
+    val id: Long? = null,
+    val label: String = "",
+) {
+    companion object {
+        fun toUiModel(tag: Tag) =
+            TagUiModel(
+                id = tag.id,
+                label = tag.label,
+            )
+    }
+}

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/mvi/MemoIntent.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/mvi/MemoIntent.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.feature.memo.mvi
 
 import com.whatever.caramel.core.viewmodel.UiIntent
+import com.whatever.caramel.feature.memo.model.TagUiModel
 
 sealed interface MemoIntent : UiIntent {
     data object Initialize : MemoIntent

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/mvi/MemoState.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/mvi/MemoState.kt
@@ -1,9 +1,8 @@
 package com.whatever.caramel.feature.memo.mvi
 
-import androidx.compose.runtime.Immutable
-import com.whatever.caramel.core.domain.entity.Memo
-import com.whatever.caramel.core.domain.entity.Tag
 import com.whatever.caramel.core.viewmodel.UiState
+import com.whatever.caramel.feature.memo.model.MemoUiModel
+import com.whatever.caramel.feature.memo.model.TagUiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -11,7 +10,7 @@ data class MemoState(
     val isMemoLoading: Boolean = true,
     val isTagLoading: Boolean = true,
     val isRefreshing: Boolean = false,
-    val memos: ImmutableList<Memo> = persistentListOf(),
+    val memos: ImmutableList<MemoUiModel> = persistentListOf(),
     val tags: ImmutableList<TagUiModel> = persistentListOf(),
     val selectedTag: TagUiModel? = null,
     val selectedChipIndex: Int = 0,
@@ -19,18 +18,4 @@ data class MemoState(
 ) : UiState {
     val isEmpty: Boolean
         get() = !isMemoLoading && memos.isEmpty()
-}
-
-@Immutable
-data class TagUiModel(
-    val id: Long? = null,
-    val label: String = "",
-) {
-    companion object {
-        fun toUiModel(tag: Tag) =
-            TagUiModel(
-                id = tag.id,
-                label = tag.label,
-            )
-    }
 }


### PR DESCRIPTION
## 관련 이슈
- #276

## 작업한 내용

<img width="303" height="283" alt="image" src="https://github.com/user-attachments/assets/fa3cc64a-dbbe-4ee4-ab49-5d604971513d" />


- 메모 일정 담당자 UI 구현
- 메모 UI 모델 분리

## PR 포인트
- 기존에 Memo 엔티티를 그대로 사용하였는데 UI 모델로 변경했습니다.
`tagListText`, `createdAt`을 사용하는게 UI 뿐이라 컴포저블에서 해주긴 보단 아에 UI로 옮기는게 맞지 않나.. 라는 생각이었습니다