### PR TITLE
[Feat] 컨텐츠 조회 - 일정 담당자 API 연동

### DIFF
--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/CalendarMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/CalendarMapper.kt
@@ -52,6 +52,6 @@ internal fun GetScheduleResponse.toScheduleDetailVO(): ScheduleDetail =
             title = title ?: "",
             description = description ?: "",
             tags = tags.map { it.toTag() },
-            contentAssignee = ContentAssignee.US, // FIXME : API 연동 후 수정 예정
+            contentAssignee = ContentAssignee.valueOf(contentAssignee.name),
         )
     }

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/ContentMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/mapper/ContentMapper.kt
@@ -23,7 +23,7 @@ internal fun MemoResponse.toMemo(): Memo =
         isCompleted = this.isCompleted,
         tagList = this.tagList.toTags(),
         createdAt = LocalDate.parse(this.createdAt),
-        role = ContentAssignee.US, // FIXME : API 연동 작업 시 변경
+        contentAssignee = ContentAssignee.valueOf(this.contentAssignee.name),
     )
 
 internal fun CursoredContentResponse.toMemosWithCursor(): MemoWithCursor =

--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Memo.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/entity/Memo.kt
@@ -10,5 +10,5 @@ data class Memo(
     val isCompleted: Boolean,
     val tagList: List<Tag>,
     val createdAt: LocalDate,
-    val role: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 )

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/mvi/ContentDetailState.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/mvi/ContentDetailState.kt
@@ -55,7 +55,7 @@ data class ContentDetailState(
     val role: ContentAssignee
         get() =
             when (contentType) {
-                ContentType.MEMO -> memoDetail?.role ?: ContentAssignee.US
+                ContentType.MEMO -> memoDetail?.contentAssignee ?: ContentAssignee.US
                 ContentType.CALENDAR -> scheduleDetail?.contentAssignee ?: ContentAssignee.US
             }
 

--- a/feature/memo/src/androidMain/kotlin/com/whatever/caramel/feature/memo/component/MemoScreenPreviewProvider.kt
+++ b/feature/memo/src/androidMain/kotlin/com/whatever/caramel/feature/memo/component/MemoScreenPreviewProvider.kt
@@ -49,7 +49,7 @@ internal class MemoScreenPreviewProvider : PreviewParameterProvider<MemoState> {
                     isCompleted = false,
                     tagList = createTempTagList(index),
                     createdAt = DateUtil.today(),
-                    role = ContentAssignee.US,
+                    contentAssignee = ContentAssignee.US,
                 ),
             )
         }


### PR DESCRIPTION
## 관련 이슈
- closes #304 

## 작업한 내용
- 컨텐츠 조회 API 연동

<img width="553" height="207" alt="image" src="https://github.com/user-attachments/assets/be48e9ee-fd2e-4608-abae-a336fcd6e906" />


