### PR TITLE
[QA] 컨텐츠 생성/수정에서 Divider 색상 지정

### DIFF
--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateScreen.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateScreen.kt
@@ -5,6 +5,7 @@ package com.whatever.caramel.feature.content.create
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.fadeIn
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -150,6 +151,7 @@ internal fun ContentScreen(
                                     horizontal = CaramelTheme.spacing.xl,
                                     vertical = CaramelTheme.spacing.m,
                                 ),
+                            color = CaramelTheme.color.divider.primary,
                         )
 
                         SelectableTagChipRow(
@@ -173,6 +175,7 @@ internal fun ContentScreen(
                                     horizontal = CaramelTheme.spacing.xl,
                                     vertical = CaramelTheme.spacing.m,
                                 ),
+                            color = CaramelTheme.color.divider.primary,
                         )
 
                         Row(

--- a/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditScreen.kt
+++ b/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditScreen.kt
@@ -163,6 +163,7 @@ internal fun ContentEditScreen(
                                     horizontal = CaramelTheme.spacing.xl,
                                     vertical = CaramelTheme.spacing.m,
                                 ),
+                            color = CaramelTheme.color.divider.primary,
                         )
 
                         SelectableTagChipRow(
@@ -186,6 +187,7 @@ internal fun ContentEditScreen(
                                     horizontal = CaramelTheme.spacing.xl,
                                     vertical = CaramelTheme.spacing.m,
                                 ),
+                            color = CaramelTheme.color.divider.primary,
                         )
 
                         Row(


### PR DESCRIPTION
## 관련 이슈
- [divider 컬러](https://www.notion.so/given-dragon/divider-23f870f222b9809e9f72cc2849bc74a9)

## 작업한 내용
- 컨텐츠 수정/생성에서의 divider 색상 지정

<img width="361" height="263" alt="image" src="https://github.com/user-attachments/assets/99f06560-5190-44e4-aba7-8125dcb6da99" />
