### PR TITLE
[QA] 메모 리스트 UI 수정

### DIFF
--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/MemoItem.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/MemoItem.kt
@@ -49,7 +49,7 @@ internal fun MemoItem(
 ) {
     val isTitleOrDescriptionEmpty = title.isEmpty() || description.isEmpty()
     val subText = description.replace(lineBreakRegex, " ")
-    val mainText = title.ifEmpty {subText }
+    val mainText = title.ifEmpty { subText }
 
     Column(
         modifier =

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/MemoItem.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/MemoItem.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -59,7 +60,6 @@ internal fun MemoItem(
                     interactionSource = null,
                     onClick = { onClickMemoItem(id) },
                 ),
-        verticalArrangement = Arrangement.spacedBy(space = CaramelTheme.spacing.xs),
     ) {
         Text(
             modifier = Modifier.fillMaxWidth(),
@@ -70,6 +70,7 @@ internal fun MemoItem(
             color = CaramelTheme.color.text.primary,
         )
         if (!isTitleOrDescriptionEmpty) {
+            Spacer(modifier = Modifier.height(CaramelTheme.spacing.xs))
             Text(
                 modifier = Modifier.fillMaxWidth(),
                 text = description,
@@ -79,6 +80,7 @@ internal fun MemoItem(
                 color = CaramelTheme.color.text.primary,
             )
         }
+        Spacer(modifier = Modifier.height(CaramelTheme.spacing.s))
         TabMetaData(
             contentAssignee = contentAssignee,
             createdDateText = createdDateText,

--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/MemoItem.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/component/MemoItem.kt
@@ -48,7 +48,8 @@ internal fun MemoItem(
     onClickMemoItem: (Long) -> Unit,
 ) {
     val isTitleOrDescriptionEmpty = title.isEmpty() || description.isEmpty()
-    val mainText = title.ifEmpty { description.replace(lineBreakRegex, "") }
+    val subText = description.replace(lineBreakRegex, " ")
+    val mainText = title.ifEmpty {subText }
 
     Column(
         modifier =
@@ -73,7 +74,7 @@ internal fun MemoItem(
             Spacer(modifier = Modifier.height(CaramelTheme.spacing.xs))
             Text(
                 modifier = Modifier.fillMaxWidth(),
-                text = description,
+                text = subText,
                 maxLines = 4,
                 overflow = TextOverflow.Ellipsis,
                 style = CaramelTheme.typography.body2.regular,


### PR DESCRIPTION
## 관련 이슈
- [메모탭에서 컴포넌트 간격 수정 필요](https://www.notion.so/given-dragon/23f870f222b98083816ae41f3d09189e)

## 작업한 내용
- 메모 본문과 메타데이터 사이의 간격 조정
- 메모 본문에서의 줄바꿈 변경

<img width="720" height="1560" alt="image" src="https://github.com/user-attachments/assets/0e69ed4d-42ac-47ac-81af-ed6f17d4f170" />
