### PR TITLE
[QA] 상세 페이지 내용 간격 수정

### DIFF
--- a/core/remote/build.gradle.kts
+++ b/core/remote/build.gradle.kts
@@ -20,9 +20,7 @@ android {
         val debugUrl = "CARAMEL_DEBUG_URL"
         val releaseUrl = "CARAMEL_RELEASE_URL"
 
-        fun getEnvOrProp(key: String): String {
-            return System.getenv(key) ?: properties.getProperty(key)
-        }
+        fun getEnvOrProp(key: String): String = System.getenv(key) ?: properties.getProperty(key)
 
         getByName("release") {
             isMinifyEnabled = false

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailScreen.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailScreen.kt
@@ -128,10 +128,10 @@ internal fun ContentDetailScreen(
             )
 
             Column(
-                modifier = Modifier.padding(top = CaramelTheme.spacing.l),
+                modifier = Modifier.padding(top = CaramelTheme.spacing.xl),
                 verticalArrangement =
                     Arrangement.spacedBy(
-                        space = CaramelTheme.spacing.l,
+                        space = CaramelTheme.spacing.xl,
                         alignment = Alignment.Top,
                     ),
             ) {


### PR DESCRIPTION
## 관련 이슈
- [상세 페이지 내 일정/태그와 본문 사이 간격이 좁음](https://www.notion.so/given-dragon/23f870f222b9804d9339fa4f9ffe32c2)

## 작업한 내용
- 컨텐츠 조회에서 각 요소들마다 margin을 xl로 변경

<img width="739" height="723" alt="image" src="https://github.com/user-attachments/assets/e578d6b9-01f4-442f-ad00-bc73aa82221a" />
