### PR TITLE
[QA] 닉네임 검증 시점 및 정규식 변경

### DIFF
--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/validator/UserValidator.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/validator/UserValidator.kt
@@ -26,15 +26,6 @@ object UserValidator {
                         errorUiType = ErrorUiType.TOAST,
                     ),
                 )
-            !input.matches(NICKNAME_VALID_PATTERN) ->
-                Result.failure(
-                    CaramelException(
-                        code = UserErrorCode.INVALID_NICKNAME_CHARACTER,
-                        message = "닉네임은 영문, 숫자, 한글만 사용할 수 있습니다.",
-                        debugMessage = "Nickname should only contain English letters, numbers, and Korean characters.",
-                        errorUiType = ErrorUiType.TOAST,
-                    ),
-                )
             else -> Result.success(Unit)
         }
 
@@ -45,11 +36,11 @@ object UserValidator {
      * */
     fun checkNicknameValidate(input: String): Result<String> =
         when {
-            input.length > NICKNAME_MAX_LENGTH ->
+            input.length !in NICKNAME_MIN_LENGTH..NICKNAME_MAX_LENGTH ->
                 Result.failure(
                     CaramelException(
                         code = UserErrorCode.INVALID_NICKNAME_LENGTH,
-                        message = "닉네임은 $NICKNAME_MIN_LENGTH 자리 이상, $NICKNAME_MAX_LENGTH 자리 이하여야 합니다.",
+                        message = "닉네임은 ${NICKNAME_MIN_LENGTH}자리 이상, ${NICKNAME_MAX_LENGTH}자리 이하여야 합니다.",
                         debugMessage =
                             "Nicknames must have at least $NICKNAME_MIN_LENGTH " +
                                 "character and no more than $NICKNAME_MAX_LENGTH characters.",
@@ -70,5 +61,5 @@ object UserValidator {
 
     const val NICKNAME_MIN_LENGTH = 2
     const val NICKNAME_MAX_LENGTH = 8
-    private val NICKNAME_VALID_PATTERN = Regex("^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]*\$")
+    private val NICKNAME_VALID_PATTERN = Regex("^[가-힣a-zA-Z0-9]+$")
 }

--- a/core/remote/build.gradle.kts
+++ b/core/remote/build.gradle.kts
@@ -20,9 +20,7 @@ android {
         val debugUrl = "CARAMEL_DEBUG_URL"
         val releaseUrl = "CARAMEL_RELEASE_URL"
 
-        fun getEnvOrProp(key: String): String {
-            return System.getenv(key) ?: properties.getProperty(key)
-        }
+        fun getEnvOrProp(key: String): String = System.getenv(key) ?: properties.getProperty(key)
 
         getByName("release") {
             isMinifyEnabled = false

--- a/feature/profile/edit/src/commonMain/kotlin/com/whatever/caramel/feature/profile/edit/ProfileEditViewModel.kt
+++ b/feature/profile/edit/src/commonMain/kotlin/com/whatever/caramel/feature/profile/edit/ProfileEditViewModel.kt
@@ -87,15 +87,12 @@ class ProfileEditViewModel(
     }
 
     private fun updateNickname(nickname: String) {
-        UserValidator
-            .checkInputNicknameValidate(nickname)
-            .onSuccess {
-                reduce {
-                    copy(
-                        nickName = nickname,
-                    )
-                }
-            }
+        UserValidator.checkInputNicknameValidate(nickname).getOrThrow()
+        reduce {
+            copy(
+                nickName = nickname,
+            )
+        }
     }
 
     private fun updateBirthdayYear(year: Int) {


### PR DESCRIPTION
## 관련 이슈
- [닉네임 생성 규칙 확인](https://www.notion.so/given-dragon/23f870f222b981d68b4bc138b0146a06)

## 작업한 내용
- 닉네임 정규식 변경
- 닉네임 정규식 적용 범위 변경

## 공유사항
- 닉네임의 입력은 최대 입력수만 체크하고 다음 Step이나 변경/생성 API를 요청 할 때 정규식과 길이 검사를 진행합니다.
- 프로필 생성 시점에서 currentStep에 따라 nextStep의 로직이 정해지기에 해당 부분 변경사항이 존재합니다.