### PR TITLE
[QA] 컨텐츠 조회 스켈레톤 UI 구현

### DIFF
--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailScreen.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/ContentDetailScreen.kt
@@ -3,40 +3,36 @@ package com.whatever.caramel.feature.content.detail
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
-import caramel.feature.content.detail.generated.resources.Res
-import caramel.feature.content.detail.generated.resources.both
-import caramel.feature.content.detail.generated.resources.memo
-import caramel.feature.content.detail.generated.resources.my
-import caramel.feature.content.detail.generated.resources.partner
-import caramel.feature.content.detail.generated.resources.schedule
 import com.whatever.caramel.core.designsystem.components.CaramelTopBar
+import com.whatever.caramel.core.designsystem.components.shimmer
 import com.whatever.caramel.core.designsystem.foundations.Resources
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
-import com.whatever.caramel.core.domain.vo.content.ContentAssignee
-import com.whatever.caramel.core.domain.vo.content.ContentType
 import com.whatever.caramel.core.ui.content.TitleTextField
-import com.whatever.caramel.feature.content.detail.components.TextWithUrlPreview
+import com.whatever.caramel.feature.content.detail.components.ContentAssigneeText
+import com.whatever.caramel.feature.content.detail.components.ContentDetailDate
+import com.whatever.caramel.feature.content.detail.components.ContentDetailDescription
+import com.whatever.caramel.feature.content.detail.components.ContentDetailInfoSkeleton
+import com.whatever.caramel.feature.content.detail.components.ContentDetailTag
 import com.whatever.caramel.feature.content.detail.mvi.ContentDetailIntent
 import com.whatever.caramel.feature.content.detail.mvi.ContentDetailState
 import org.jetbrains.compose.resources.painterResource
-import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun ContentDetailScreen(
@@ -45,17 +41,6 @@ internal fun ContentDetailScreen(
 ) {
     val uriHandler = LocalUriHandler.current
     val verticalScrollState = rememberScrollState()
-    val (assigneeTextRes, assigneeTextColor) =
-        when (state.role) {
-            ContentAssignee.ME -> Res.string.my to CaramelTheme.color.text.labelAccent4
-            ContentAssignee.PARTNER -> Res.string.partner to CaramelTheme.color.text.primary
-            ContentAssignee.US -> Res.string.both to CaramelTheme.color.text.brand
-        }
-    val contentTypeRes =
-        when (state.contentType) {
-            ContentType.MEMO -> Res.string.memo
-            ContentType.CALENDAR -> Res.string.schedule
-        }
 
     Column(
         modifier =
@@ -112,93 +97,70 @@ internal fun ContentDetailScreen(
                     .padding(horizontal = CaramelTheme.spacing.xl)
                     .verticalScroll(verticalScrollState),
         ) {
-            Text(
+            ContentAssigneeText(
                 modifier = Modifier.padding(top = CaramelTheme.spacing.xs),
-                text = stringResource(assigneeTextRes) + " " + stringResource(contentTypeRes),
-                color = assigneeTextColor,
-                style = CaramelTheme.typography.body2.bold,
+                contentType = state.contentType,
+                contentAssignee = state.contentAssignee,
+                isLoading = state.isLoading,
             )
-            TitleTextField(
-                modifier =
-                    Modifier.padding(top = CaramelTheme.spacing.m),
-                value = state.title,
-                onValueChange = {},
-                onKeyboardAction = {},
-                readOnly = true,
-            )
-
+            if (state.isLoading) {
+                Box(
+                    modifier =
+                        Modifier
+                            .padding(top = CaramelTheme.spacing.m)
+                            .shimmer(shape = CaramelTheme.shape.xs)
+                            .fillMaxWidth()
+                            .height(height = 36.dp),
+                )
+            } else {
+                TitleTextField(
+                    modifier =
+                        Modifier.padding(top = CaramelTheme.spacing.m),
+                    value = state.title,
+                    onValueChange = {},
+                    onKeyboardAction = {},
+                    readOnly = true,
+                )
+            }
             Column(
-                modifier = Modifier.padding(top = CaramelTheme.spacing.l),
+                modifier = Modifier.padding(top = CaramelTheme.spacing.xl),
                 verticalArrangement =
                     Arrangement.spacedBy(
-                        space = CaramelTheme.spacing.l,
+                        space = CaramelTheme.spacing.xl,
                         alignment = Alignment.Top,
                     ),
             ) {
-                if (state.scheduleDetail != null) {
-                    HorizontalDivider(color = CaramelTheme.color.divider.primary)
-                    Row(
+                if (state.isLoading) {
+                    ContentDetailInfoSkeleton(
                         modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement =
-                            Arrangement.spacedBy(
-                                space = CaramelTheme.spacing.s,
-                                alignment = Alignment.Start,
-                            ),
-                    ) {
-                        Icon(
-                            painter = painterResource(resource = Resources.Icon.ic_calendar_18),
-                            tint = CaramelTheme.color.icon.primary,
-                            contentDescription = null,
-                        )
-                        Text(
-                            text = state.date,
-                            style = CaramelTheme.typography.body2.regular,
-                            color = CaramelTheme.color.text.primary,
-                        )
-                        Text(
-                            text = state.time,
-                            style = CaramelTheme.typography.body2.regular,
-                            color = CaramelTheme.color.text.primary,
-                        )
-                    }
-                }
-                if (state.tags.isNotEmpty()) {
-                    HorizontalDivider(color = CaramelTheme.color.divider.primary)
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement =
-                            Arrangement.spacedBy(
-                                space = CaramelTheme.spacing.s,
-                                alignment = Alignment.Start,
-                            ),
-                    ) {
-                        Icon(
-                            painter = painterResource(resource = Resources.Icon.ic_tag_18),
-                            tint = CaramelTheme.color.icon.primary,
-                            contentDescription = null,
-                        )
-                        Text(
-                            text = state.tagString,
-                            style = CaramelTheme.typography.body2.regular,
-                            color = CaramelTheme.color.text.primary,
-                        )
-                    }
-                }
-                if (state.description.isNotEmpty()) {
-                    HorizontalDivider(color = CaramelTheme.color.divider.primary)
-                    TextWithUrlPreview(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(bottom = 50.dp),
-                        text = state.description,
-                        linkMetaData = state.linkMetaDataList.toList(),
-                        onLinkPreviewClick = {
-                            uriHandler.openUri(it)
-                        },
                     )
+                } else {
+                    if (state.scheduleDetail != null) {
+                        ContentDetailDate(
+                            modifier = Modifier.fillMaxWidth(),
+                            dateText = state.date,
+                            timeText = state.time,
+                        )
+                    }
+                    if (state.tags.isNotEmpty()) {
+                        ContentDetailTag(
+                            modifier = Modifier.fillMaxWidth(),
+                            tagString = state.tagString,
+                        )
+                    }
+                    if (state.description.isNotEmpty()) {
+                        ContentDetailDescription(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(bottom = 50.dp),
+                            description = state.description,
+                            linkMetaDataList = state.linkMetaDataList,
+                            onLinkPreviewClick = {
+                                uriHandler.openUri(it)
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/components/ContentAssigne.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/components/ContentAssigne.kt
@@ -1,0 +1,60 @@
+package com.whatever.caramel.feature.content.detail.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import caramel.feature.content.detail.generated.resources.Res
+import caramel.feature.content.detail.generated.resources.both
+import caramel.feature.content.detail.generated.resources.memo
+import caramel.feature.content.detail.generated.resources.my
+import caramel.feature.content.detail.generated.resources.partner
+import caramel.feature.content.detail.generated.resources.schedule
+import com.whatever.caramel.core.designsystem.components.shimmer
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.core.domain.vo.content.ContentAssignee
+import com.whatever.caramel.core.domain.vo.content.ContentType
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun ContentAssigneeText(
+    modifier: Modifier,
+    isLoading: Boolean,
+    contentType: ContentType,
+    contentAssignee: ContentAssignee,
+) {
+    if (isLoading) {
+        ContentAssigneeTextSkeleton(modifier = modifier)
+    } else {
+        val (assigneeTextRes, assigneeTextColor) =
+            when (contentAssignee) {
+                ContentAssignee.ME -> Res.string.my to CaramelTheme.color.text.labelAccent4
+                ContentAssignee.PARTNER -> Res.string.partner to CaramelTheme.color.text.primary
+                ContentAssignee.US -> Res.string.both to CaramelTheme.color.text.brand
+            }
+
+        val contentTypeRes =
+            when (contentType) {
+                ContentType.MEMO -> Res.string.memo
+                ContentType.CALENDAR -> Res.string.schedule
+            }
+        Text(
+            modifier = modifier,
+            text = stringResource(assigneeTextRes) + " " + stringResource(contentTypeRes),
+            color = assigneeTextColor,
+            style = CaramelTheme.typography.body2.bold,
+        )
+    }
+}
+
+@Composable
+internal fun ContentAssigneeTextSkeleton(modifier: Modifier = Modifier) {
+    Box(
+        modifier =
+            modifier
+                .size(width = 60.dp, height = 23.dp)
+                .shimmer(shape = CaramelTheme.shape.xs),
+    )
+}

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/components/ContentDetailInfo.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/components/ContentDetailInfo.kt
@@ -1,0 +1,159 @@
+package com.whatever.caramel.feature.content.detail.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.whatever.caramel.core.designsystem.components.shimmer
+import com.whatever.caramel.core.designsystem.foundations.Resources
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.core.domain.vo.common.LinkMetaData
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+internal fun ContentDetailDescription(
+    modifier: Modifier = Modifier,
+    description: String,
+    linkMetaDataList: List<LinkMetaData>,
+    onLinkPreviewClick: (String) -> Unit,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement =
+            Arrangement.spacedBy(
+                space = CaramelTheme.spacing.xl,
+                alignment = Alignment.Top,
+            ),
+    ) {
+        HorizontalDivider(color = CaramelTheme.color.divider.primary)
+        TextWithUrlPreview(
+            text = description,
+            linkMetaData = linkMetaDataList,
+            onLinkPreviewClick = {
+                onLinkPreviewClick(it)
+            },
+        )
+    }
+}
+
+@Composable
+internal fun ContentDetailTag(
+    modifier: Modifier = Modifier,
+    tagString: String,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement =
+            Arrangement.spacedBy(
+                space = CaramelTheme.spacing.xl,
+                alignment = Alignment.Top,
+            ),
+    ) {
+        HorizontalDivider(color = CaramelTheme.color.divider.primary)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement =
+                Arrangement.spacedBy(
+                    space = CaramelTheme.spacing.s,
+                    alignment = Alignment.Start,
+                ),
+        ) {
+            Icon(
+                painter = painterResource(resource = Resources.Icon.ic_tag_18),
+                tint = CaramelTheme.color.icon.primary,
+                contentDescription = null,
+            )
+            Text(
+                text = tagString,
+                style = CaramelTheme.typography.body2.regular,
+                color = CaramelTheme.color.text.primary,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun ContentDetailDate(
+    modifier: Modifier = Modifier,
+    dateText: String,
+    timeText: String,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement =
+            Arrangement.spacedBy(
+                space = CaramelTheme.spacing.xl,
+                alignment = Alignment.Top,
+            ),
+    ) {
+        HorizontalDivider(color = CaramelTheme.color.divider.primary)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement =
+                Arrangement.spacedBy(
+                    space = CaramelTheme.spacing.s,
+                    alignment = Alignment.Start,
+                ),
+        ) {
+            Icon(
+                painter = painterResource(resource = Resources.Icon.ic_calendar_18),
+                tint = CaramelTheme.color.icon.primary,
+                contentDescription = null,
+            )
+            Text(
+                text = dateText,
+                style = CaramelTheme.typography.body2.regular,
+                color = CaramelTheme.color.text.primary,
+            )
+            Text(
+                text = timeText,
+                style = CaramelTheme.typography.body2.regular,
+                color = CaramelTheme.color.text.primary,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun ContentDetailInfoSkeleton(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        verticalArrangement =
+            Arrangement.spacedBy(
+                space = CaramelTheme.spacing.xl,
+                alignment = Alignment.Top,
+            ),
+    ) {
+        HorizontalDivider(color = CaramelTheme.color.divider.primary)
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(space = CaramelTheme.spacing.s),
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(height = 23.dp)
+                        .shimmer(shape = CaramelTheme.shape.xs),
+            )
+            Box(
+                modifier =
+                    Modifier
+                        .size(width = 200.dp, height = 23.dp)
+                        .shimmer(shape = CaramelTheme.shape.xs),
+            )
+        }
+    }
+}

--- a/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/mvi/ContentDetailState.kt
+++ b/feature/content/detail/src/commonMain/kotlin/com/whatever/caramel/feature/content/detail/mvi/ContentDetailState.kt
@@ -52,7 +52,7 @@ data class ContentDetailState(
             return "${parsed.year}년 ${parsed.monthNumber}월 ${parsed.dayOfMonth}일"
         }
 
-    val role: ContentAssignee
+    val contentAssignee: ContentAssignee
         get() =
             when (contentType) {
                 ContentType.MEMO -> memoDetail?.contentAssignee ?: ContentAssignee.US


### PR DESCRIPTION
## 관련 이슈
- [컨텐츠 조회 스켈레톤 추가](https://www.notion.so/given-dragon/23f870f222b981ff9884eec2fde92ea9)

## 작업한 내용
- 스켈레톤 추가

<img width="703" height="328" alt="image" src="https://github.com/user-attachments/assets/ccbb9fa0-acec-42e7-babf-371a769ab631" />

- 컴포넌트 분리

## PR 포인트
- 컴포넌트 분리를 했는데 Arrangement.spacedBy가 적용되어있어 모든 컴포넌트에 Column이 추가되었습니다.. Screen의 가독성을 챙길지, 불필요한 값을 정리할지 고민이군요.
  - 개인적으로는 가독성을 챙길려고 하는데 컴포넌트로 빼기도 애매한 놈이더군요