### PR TITLE
[Hotfix] Android-1.0.3.1 / iOS-1.0.4

### DIFF
--- a/app-ios/iosApp.xcodeproj/project.pbxproj
+++ b/app-ios/iosApp.xcodeproj/project.pbxproj
@@ -410,7 +410,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000307;
+				CURRENT_PROJECT_VERSION = 100000401;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AR6HWFH5V3;
@@ -426,7 +426,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -453,7 +453,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000307;
+				CURRENT_PROJECT_VERSION = 100000401;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AR6HWFH5V3;
@@ -469,7 +469,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/app-ios/iosApp/Info.plist
+++ b/app-ios/iosApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>1.0.4</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -42,7 +42,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>10000307</string>
+	<string>10000401</string>
 	<key>CaramelBaseUrl</key>
 	<string>$(CARAMEL_BASE_URL)</string>
 	<key>CaramelSampleUrl</key>

--- a/core/ui/src/androidMain/kotlin/com/whatever/caramel/core/ui/list/picker/CaramelTimePickerPreview.kt
+++ b/core/ui/src/androidMain/kotlin/com/whatever/caramel/core/ui/list/picker/CaramelTimePickerPreview.kt
@@ -20,11 +20,12 @@ private fun CaramelTimePickerPreview() {
             contentAlignment = Alignment.Center,
         ) {
             CaramelTimePicker(
-                timeUiState = TimeUiState(
-                    period = "오전",
-                    hour = "12",
-                    minute = "00",
-                ),
+                timeUiState =
+                    TimeUiState(
+                        period = "오전",
+                        hour = "12",
+                        minute = "00",
+                    ),
                 onMinuteChanged = { minute -> Napier.d { "minute changed: $minute" } },
                 onHourChanged = { hour -> Napier.d { "hour changed: $hour" } },
                 onPeriodChanged = { period -> Napier.d { "period changed: $period" } },

--- a/core/ui/src/androidMain/kotlin/com/whatever/caramel/core/ui/list/picker/CaramelTimePickerPreview.kt
+++ b/core/ui/src/androidMain/kotlin/com/whatever/caramel/core/ui/list/picker/CaramelTimePickerPreview.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
 import com.whatever.caramel.core.ui.picker.CaramelTimePicker
-import com.whatever.caramel.core.ui.picker.TimeUiState
+import com.whatever.caramel.core.ui.picker.model.TimeUiState
 import io.github.aakira.napier.Napier
 
 @Preview
@@ -20,7 +20,11 @@ private fun CaramelTimePickerPreview() {
             contentAlignment = Alignment.Center,
         ) {
             CaramelTimePicker(
-                timeUiState = TimeUiState.default(),
+                timeUiState = TimeUiState(
+                    period = "오전",
+                    hour = "12",
+                    minute = "00",
+                ),
                 onMinuteChanged = { minute -> Napier.d { "minute changed: $minute" } },
                 onHourChanged = { hour -> Napier.d { "hour changed: $hour" } },
                 onPeriodChanged = { period -> Napier.d { "period changed: $period" } },

--- a/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/picker/CaramelTimePicker.kt
+++ b/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/picker/CaramelTimePicker.kt
@@ -17,40 +17,8 @@ import com.whatever.caramel.core.designsystem.components.PickerScrollMode.BOUNDE
 import com.whatever.caramel.core.designsystem.components.PickerScrollMode.LOOPING
 import com.whatever.caramel.core.designsystem.components.rememberPickerState
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
-import kotlinx.datetime.LocalDateTime
-
-data class TimeUiState(
-    val period: String,
-    val hour: String,
-    val minute: String,
-) {
-    companion object {
-        fun default(): TimeUiState =
-            TimeUiState(
-                period = Period.AM.value,
-                hour = "12",
-                minute = "00",
-            )
-
-        fun from(dateTime: LocalDateTime): TimeUiState {
-            val currentHour = dateTime.hour
-            val period = if (currentHour < 12) "오전" else "오후"
-            val hourIn12 = if (currentHour == 0 || currentHour == 12) 12 else currentHour % 12
-            return TimeUiState(
-                period = period,
-                hour = hourIn12.toString(),
-                minute = dateTime.minute.toString(),
-            )
-        }
-    }
-}
-
-enum class Period(
-    val value: String,
-) {
-    AM(value = "오전"),
-    PM(value = "오후"),
-}
+import com.whatever.caramel.core.ui.picker.model.Period
+import com.whatever.caramel.core.ui.picker.model.TimeUiState
 
 @Composable
 fun CaramelTimePicker(

--- a/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/picker/model/DateUiState.kt
+++ b/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/picker/model/DateUiState.kt
@@ -38,5 +38,4 @@ data class DateUiState(
     }
 }
 
-fun DateUiState.toLocalDate(): LocalDate =
-    LocalDate(year, month, day)
+fun DateUiState.toLocalDate(): LocalDate = LocalDate(year, month, day)

--- a/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/picker/model/DateUiState.kt
+++ b/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/picker/model/DateUiState.kt
@@ -1,9 +1,9 @@
 package com.whatever.caramel.core.ui.picker.model
 
 import com.whatever.caramel.core.util.DateUtil
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 
-// @ham2174 FIXME : DateMonthPicker 또는 DatePicker 의 상태 변경시 DateUiState / DateMonthUiState 로 분리
 data class DateUiState(
     val year: Int,
     val month: Int,
@@ -37,3 +37,6 @@ data class DateUiState(
             )
     }
 }
+
+fun DateUiState.toLocalDate(): LocalDate =
+    LocalDate(year, month, day)

--- a/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/picker/model/TImeUiState.kt
+++ b/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/picker/model/TImeUiState.kt
@@ -42,9 +42,11 @@ enum class Period(
 
 fun TimeUiState.toLocalTime(): LocalTime =
     LocalTime(
-        hour = if (period == "오전") {
-            hour.toInt()
-        } else {
-            hour.toInt() + 12
-        },
-        minute = minute.toInt())
+        hour =
+            if (period == "오전") {
+                hour.toInt()
+            } else {
+                hour.toInt() + 12
+            },
+        minute = minute.toInt(),
+    )

--- a/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/picker/model/TImeUiState.kt
+++ b/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/picker/model/TImeUiState.kt
@@ -1,0 +1,50 @@
+package com.whatever.caramel.core.ui.picker.model
+
+import com.whatever.caramel.core.util.DateUtil
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+
+data class TimeUiState(
+    val period: String,
+    val hour: String,
+    val minute: String,
+) {
+    companion object {
+        fun currentTime(): TimeUiState {
+            val now = DateUtil.todayLocalDateTime().time
+
+            return TimeUiState(
+                period = if (now.hour < 12) "오전" else "오후",
+                hour = now.hour.toString(),
+                minute = now.minute.toString(),
+            )
+        }
+
+        fun from(dateTime: LocalDateTime): TimeUiState {
+            val currentHour = dateTime.hour
+            val period = if (currentHour < 12) "오전" else "오후"
+            val hourIn12 = if (currentHour == 0 || currentHour == 12) 12 else currentHour % 12
+            return TimeUiState(
+                period = period,
+                hour = hourIn12.toString(),
+                minute = dateTime.minute.toString(),
+            )
+        }
+    }
+}
+
+enum class Period(
+    val value: String,
+) {
+    AM(value = "오전"),
+    PM(value = "오후"),
+}
+
+fun TimeUiState.toLocalTime(): LocalTime =
+    LocalTime(
+        hour = if (period == "오전") {
+            hour.toInt()
+        } else {
+            hour.toInt() + 12
+        },
+        minute = minute.toInt())

--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateScreen.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateScreen.kt
@@ -324,7 +324,7 @@ internal fun ContentScreen(
                     buttonSize = CaramelButtonSize.Large,
                     text = "완료",
                     onClick = {
-                        onIntent(ContentCreateIntent.HideDateTimeDialog)
+                        onIntent(ContentCreateIntent.ClickCompleteButton)
                     },
                 )
             },

--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateScreen.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateScreen.kt
@@ -5,7 +5,6 @@ package com.whatever.caramel.feature.content.create
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.fadeIn
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -49,8 +48,6 @@ import com.whatever.caramel.core.ui.content.TagChip
 import com.whatever.caramel.core.ui.content.TitleTextField
 import com.whatever.caramel.core.ui.picker.CaramelDatePicker
 import com.whatever.caramel.core.ui.picker.CaramelTimePicker
-import com.whatever.caramel.core.ui.picker.TimeUiState
-import com.whatever.caramel.core.ui.picker.model.DateUiState
 import com.whatever.caramel.core.ui.util.rememberKeyboardVisibleState
 import com.whatever.caramel.feature.content.create.mvi.ContentCreateIntent
 import com.whatever.caramel.feature.content.create.mvi.ContentCreateState
@@ -285,7 +282,7 @@ internal fun ContentScreen(
                                 Modifier
                                     .padding(top = CaramelTheme.spacing.xxl)
                                     .align(Alignment.CenterHorizontally),
-                            dateUiState = DateUiState.from(state.dateTime),
+                            dateUiState = state.dateUiState,
                             onYearChanged = { year ->
                                 onIntent(ContentCreateIntent.OnYearChanged(year))
                             },
@@ -304,7 +301,7 @@ internal fun ContentScreen(
                                 Modifier
                                     .padding(top = CaramelTheme.spacing.xxl)
                                     .align(Alignment.CenterHorizontally),
-                            timeUiState = TimeUiState.from(state.dateTime),
+                            timeUiState = state.timeUiState,
                             onPeriodChanged = { period ->
                                 onIntent(ContentCreateIntent.OnPeriodChanged(period))
                             },

--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
@@ -14,9 +14,11 @@ import com.whatever.caramel.core.domain.vo.content.ContentParameterType
 import com.whatever.caramel.core.domain.vo.content.ContentType
 import com.whatever.caramel.core.domain.vo.memo.MemoParameter
 import com.whatever.caramel.core.ui.content.CreateMode
+import com.whatever.caramel.core.ui.picker.model.DateUiState
+import com.whatever.caramel.core.ui.picker.model.TimeUiState
+import com.whatever.caramel.core.ui.picker.model.toLocalDate
 import com.whatever.caramel.core.util.DateUtil
 import com.whatever.caramel.core.util.TimeUtil.roundToNearest5Minutes
-import com.whatever.caramel.core.util.copy
 import com.whatever.caramel.core.viewmodel.BaseViewModel
 import com.whatever.caramel.feature.content.create.mvi.ContentCreateIntent
 import com.whatever.caramel.feature.content.create.mvi.ContentCreateSideEffect
@@ -168,28 +170,25 @@ class ContentCreateViewModel(
 
     private fun selectCreateMode(intent: ContentCreateIntent.SelectCreateMode) {
         reduce {
-            copy(
-                createMode = intent.createMode,
-                dateTime =
-                    if (intent.createMode == CreateMode.CALENDAR) {
-                        val now = DateUtil.todayLocalDateTime()
-                        roundToNearest5Minutes(dateTime = now)
-                    } else {
-                        dateTime
-                    },
-            )
+            copy(createMode = intent.createMode)
         }
     }
 
     private fun clickDate(intent: ContentCreateIntent.ClickDate) {
         reduce {
-            copy(showDateDialog = true)
+            copy(
+                showDateDialog = true,
+                dateUiState = DateUiState.from(dateTime = dateTime),
+            )
         }
     }
 
     private fun clickTime(intent: ContentCreateIntent.ClickTime) {
         reduce {
-            copy(showTimeDialog = true)
+            copy(
+                showTimeDialog = true,
+                timeUiState = TimeUiState.from(dateTime = dateTime),
+            )
         }
     }
 
@@ -200,54 +199,27 @@ class ContentCreateViewModel(
     }
 
     private fun updateYear(intent: ContentCreateIntent.OnYearChanged) {
-        reduce { copy(dateTime = dateTime.copy(year = intent.year)) }
+        reduce { copy(dateUiState = dateUiState.copy(year = intent.year)) }
     }
 
     private fun updateMonth(intent: ContentCreateIntent.OnMonthChanged) {
-        reduce { copy(dateTime = dateTime.copy(monthNumber = intent.month)) }
+        reduce { copy(dateUiState = dateUiState.copy(month = intent.month)) }
     }
 
     private fun updateDay(intent: ContentCreateIntent.OnDayChanged) {
-        reduce { copy(dateTime = dateTime.copy(dayOfMonth = intent.day)) }
+        reduce { copy(dateUiState = dateUiState.copy(day = intent.day)) }
     }
 
     private fun updateMinute(intent: ContentCreateIntent.OnMinuteChanged) {
-        val minute = intent.minute.toIntOrNull() ?: currentState.dateTime.minute
-        reduce { copy(dateTime = dateTime.copy(minute = minute)) }
+        reduce { copy(timeUiState = timeUiState.copy(minute = intent.minute)) }
     }
 
     private fun updateHour(intent: ContentCreateIntent.OnHourChanged) {
-        val newHour12 = intent.hour.toIntOrNull() ?: return
-
-        reduce {
-            val currentDateTime = dateTime
-            val currentHour24 = currentDateTime.hour
-            val newHour24 =
-                when {
-                    currentHour24 < 12 -> { // 현재 AM
-                        if (newHour12 == 12) 0 else newHour12 // 12 AM은 0시, 나머지는 그대로
-                    }
-
-                    else -> { // 현재 PM
-                        if (newHour12 == 12) 12 else newHour12 + 12 // 12 PM은 12시, 나머지는 +12
-                    }
-                }
-            copy(dateTime = currentDateTime.copy(hour = newHour24))
-        }
+        reduce { copy(timeUiState = timeUiState.copy(hour = intent.hour)) }
     }
 
     private fun updatePeriod(intent: ContentCreateIntent.OnPeriodChanged) {
-        reduce {
-            val currentDateTime = dateTime
-            val currentHour24 = currentDateTime.hour
-            val finalNewHour24 =
-                when (intent.period) {
-                    "오전" -> if (currentHour24 >= 12) currentHour24 - 12 else currentHour24 // PM -> AM
-                    "오후" -> if (currentHour24 < 12) currentHour24 + 12 else currentHour24 // AM -> PM
-                    else -> currentHour24
-                }
-            copy(dateTime = currentDateTime.copy(hour = finalNewHour24))
-        }
+        reduce { copy(timeUiState = timeUiState.copy(period = intent.period)) }
     }
 
     private fun clickSaveButton(intent: ContentCreateIntent.ClickSaveButton) {

--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/ContentCreateViewModel.kt
@@ -123,29 +123,31 @@ class ContentCreateViewModel(
 
     private fun clickComplete(intent: ContentCreateIntent.ClickCompleteButton) {
         val localDate = currentState.dateUiState.toLocalDate()
-        val localTime = with(currentState.timeUiState) {
-            val hour = this.hour.toInt()
-            val minute = this.minute.toInt()
-            val convertedHour = when (period) {
-                "오후" -> if (hour == 12) 12 else hour + 12 // 오후 : 12 ~ 23
-                "오전" -> if (hour == 12) 0 else hour // 오전 : 00 ~ 11
-                else -> throw CaramelException(
-                    code = AppErrorCode.UNKNOWN,
-                    message = "알 수 없는 오류 입니다.",
-                    debugMessage = "잘못된 Period",
-                    errorUiType = ErrorUiType.TOAST,
-                )
-            }
+        val localTime =
+            with(currentState.timeUiState) {
+                val hour = this.hour.toInt()
+                val minute = this.minute.toInt()
+                val convertedHour =
+                    when (period) {
+                        "오후" -> if (hour == 12) 12 else hour + 12 // 오후 : 12 ~ 23
+                        "오전" -> if (hour == 12) 0 else hour // 오전 : 00 ~ 11
+                        else -> throw CaramelException(
+                            code = AppErrorCode.UNKNOWN,
+                            message = "알 수 없는 오류 입니다.",
+                            debugMessage = "잘못된 Period",
+                            errorUiType = ErrorUiType.TOAST,
+                        )
+                    }
 
-            LocalTime(hour = convertedHour, minute = minute)
-        }
+                LocalTime(hour = convertedHour, minute = minute)
+            }
         val localDateTime = localDate.atTime(time = localTime)
 
         reduce {
             copy(
                 showDateDialog = false,
                 showTimeDialog = false,
-                dateTime = localDateTime
+                dateTime = localDateTime,
             )
         }
     }

--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/mvi/ContentCreateIntent.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/mvi/ContentCreateIntent.kt
@@ -36,6 +36,8 @@ sealed interface ContentCreateIntent : UiIntent {
 
     data object HideDateTimeDialog : ContentCreateIntent
 
+    data object ClickCompleteButton : ContentCreateIntent
+
     data class OnYearChanged(
         val year: Int,
     ) : ContentCreateIntent

--- a/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/mvi/ContentCreateState.kt
+++ b/feature/content/create/src/commonMain/kotlin/com/whatever/caramel/feature/content/create/mvi/ContentCreateState.kt
@@ -3,6 +3,8 @@ package com.whatever.caramel.feature.content.create.mvi
 import com.whatever.caramel.core.domain.entity.Tag
 import com.whatever.caramel.core.ui.content.ContentAssigneeUiModel
 import com.whatever.caramel.core.ui.content.CreateMode
+import com.whatever.caramel.core.ui.picker.model.DateUiState
+import com.whatever.caramel.core.ui.picker.model.TimeUiState
 import com.whatever.caramel.core.util.DateUtil
 import com.whatever.caramel.core.viewmodel.UiState
 import kotlinx.collections.immutable.ImmutableList
@@ -22,6 +24,8 @@ data class ContentCreateState(
     val showDateDialog: Boolean = false,
     val showTimeDialog: Boolean = false,
     val dateTime: LocalDateTime = DateUtil.todayLocalDateTime(),
+    val dateUiState: DateUiState = DateUiState.currentDate(),
+    val timeUiState: TimeUiState = TimeUiState.currentTime(),
     val showEditConfirmDialog: Boolean = false,
 ) : UiState {
     val isSaveButtonEnable: Boolean

--- a/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditScreen.kt
+++ b/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditScreen.kt
@@ -61,8 +61,6 @@ import com.whatever.caramel.core.ui.content.TagChip
 import com.whatever.caramel.core.ui.content.TitleTextField
 import com.whatever.caramel.core.ui.picker.CaramelDatePicker
 import com.whatever.caramel.core.ui.picker.CaramelTimePicker
-import com.whatever.caramel.core.ui.picker.TimeUiState
-import com.whatever.caramel.core.ui.picker.model.DateUiState
 import com.whatever.caramel.feature.content.edit.mvi.ContentEditIntent
 import com.whatever.caramel.feature.content.edit.mvi.ContentEditState
 import kotlinx.collections.immutable.toImmutableList
@@ -317,16 +315,13 @@ internal fun ContentEditScreen(
                                 Modifier
                                     .padding(top = CaramelTheme.spacing.xxl)
                                     .align(Alignment.CenterHorizontally),
-                            dateUiState = DateUiState.from(state.dateTime),
-                            onYearChanged = { year -> onIntent(ContentEditIntent.OnYearChanged(year)) },
+                            dateUiState = state.dateUiState,
+                            onYearChanged = { year ->
+                                onIntent(ContentEditIntent.OnYearChanged(year)) },
                             onMonthChanged = { month ->
-                                onIntent(
-                                    ContentEditIntent.OnMonthChanged(
-                                        month,
-                                    ),
-                                )
-                            },
-                            onDayChanged = { day -> onIntent(ContentEditIntent.OnDayChanged(day)) },
+                                onIntent(ContentEditIntent.OnMonthChanged(month)) },
+                            onDayChanged = { day ->
+                                onIntent(ContentEditIntent.OnDayChanged(day)) },
                         )
                     }
 
@@ -336,7 +331,7 @@ internal fun ContentEditScreen(
                                 Modifier
                                     .padding(top = CaramelTheme.spacing.xxl)
                                     .align(Alignment.CenterHorizontally),
-                            timeUiState = TimeUiState.from(state.dateTime),
+                            timeUiState = state.timeUiState,
                             onPeriodChanged = { period ->
                                 onIntent(
                                     ContentEditIntent.OnPeriodChanged(
@@ -364,7 +359,7 @@ internal fun ContentEditScreen(
                     buttonType = CaramelButtonType.Enabled1,
                     buttonSize = CaramelButtonSize.Large,
                     text = "완료",
-                    onClick = { onIntent(ContentEditIntent.HideDateTimeDialog) },
+                    onClick = { onIntent(ContentEditIntent.ClickCompleteButton) },
                 )
             },
         )

--- a/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditScreen.kt
+++ b/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditScreen.kt
@@ -317,11 +317,14 @@ internal fun ContentEditScreen(
                                     .align(Alignment.CenterHorizontally),
                             dateUiState = state.dateUiState,
                             onYearChanged = { year ->
-                                onIntent(ContentEditIntent.OnYearChanged(year)) },
+                                onIntent(ContentEditIntent.OnYearChanged(year))
+                            },
                             onMonthChanged = { month ->
-                                onIntent(ContentEditIntent.OnMonthChanged(month)) },
+                                onIntent(ContentEditIntent.OnMonthChanged(month))
+                            },
                             onDayChanged = { day ->
-                                onIntent(ContentEditIntent.OnDayChanged(day)) },
+                                onIntent(ContentEditIntent.OnDayChanged(day))
+                            },
                         )
                     }
 

--- a/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditViewModel.kt
+++ b/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/ContentEditViewModel.kt
@@ -140,29 +140,31 @@ class ContentEditViewModel(
 
     private fun clickComplete(intent: ContentEditIntent.ClickCompleteButton) {
         val localDate = currentState.dateUiState.toLocalDate()
-        val localTime = with(currentState.timeUiState) {
-            val hour = this.hour.toInt()
-            val minute = this.minute.toInt()
-            val convertedHour = when (period) {
-                "오후" -> if (hour == 12) 12 else hour + 12 // 오후 : 12 ~ 23
-                "오전" -> if (hour == 12) 0 else hour // 오전 : 00 ~ 11
-                else -> throw CaramelException(
-                    code = AppErrorCode.UNKNOWN,
-                    message = "알 수 없는 오류 입니다.",
-                    debugMessage = "잘못된 Period",
-                    errorUiType = ErrorUiType.TOAST,
-                )
-            }
+        val localTime =
+            with(currentState.timeUiState) {
+                val hour = this.hour.toInt()
+                val minute = this.minute.toInt()
+                val convertedHour =
+                    when (period) {
+                        "오후" -> if (hour == 12) 12 else hour + 12 // 오후 : 12 ~ 23
+                        "오전" -> if (hour == 12) 0 else hour // 오전 : 00 ~ 11
+                        else -> throw CaramelException(
+                            code = AppErrorCode.UNKNOWN,
+                            message = "알 수 없는 오류 입니다.",
+                            debugMessage = "잘못된 Period",
+                            errorUiType = ErrorUiType.TOAST,
+                        )
+                    }
 
-            LocalTime(hour = convertedHour, minute = minute)
-        }
+                LocalTime(hour = convertedHour, minute = minute)
+            }
         val localDateTime = localDate.atTime(time = localTime)
 
         reduce {
             copy(
                 showDateDialog = false,
                 showTimeDialog = false,
-                dateTime = localDateTime
+                dateTime = localDateTime,
             )
         }
     }

--- a/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/mvi/ContentEditIntent.kt
+++ b/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/mvi/ContentEditIntent.kt
@@ -30,6 +30,8 @@ sealed interface ContentEditIntent : UiIntent {
 
     data object DismissDeletedContentDialog : ContentEditIntent
 
+    data object ClickCompleteButton : ContentEditIntent
+
     data class ClickAssignee(
         val assignee: ContentAssigneeUiModel,
     ) : ContentEditIntent

--- a/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/mvi/ContentEditState.kt
+++ b/feature/content/edit/src/commonMain/kotlin/com/whatever/caramel/feature/content/edit/mvi/ContentEditState.kt
@@ -4,6 +4,8 @@ import com.whatever.caramel.core.domain.entity.Tag
 import com.whatever.caramel.core.domain.vo.content.ContentType
 import com.whatever.caramel.core.ui.content.ContentAssigneeUiModel
 import com.whatever.caramel.core.ui.content.CreateMode
+import com.whatever.caramel.core.ui.picker.model.DateUiState
+import com.whatever.caramel.core.ui.picker.model.TimeUiState
 import com.whatever.caramel.core.util.DateUtil
 import com.whatever.caramel.core.viewmodel.UiState
 import kotlinx.collections.immutable.ImmutableList
@@ -25,6 +27,8 @@ data class ContentEditState(
     val showDateDialog: Boolean = false,
     val showTimeDialog: Boolean = false,
     val dateTime: LocalDateTime = DateUtil.todayLocalDateTime(),
+    val dateUiState: DateUiState = DateUiState.currentDate(),
+    val timeUiState: TimeUiState = TimeUiState.currentTime(),
     val showExitConfirmDialog: Boolean = false,
     val showDeleteConfirmDialog: Boolean = false,
     val showDeletedContentDialog: Boolean = false,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@ agp = "8.9.1"
 android-compileSdk = "35"
 android-minSdk = "28"
 android-targetSdk = "35"
-version-code = "10000307" # major(10), minor(00), patch(03), build(00)
-version-name = "1.0.3" # major(1), minor(0), patch(0)
+version-code = "10000309" # major(10), minor(00), patch(03), build(00)
+version-name = "1.0.3.1" # major(1), minor(0), patch(0)
 
 androidx-activityCompose = "1.10.1"
 androidx-appcompat = "1.7.1"


### PR DESCRIPTION
## 관련 이슈
- closes #336 

## 작업한 내용
- Android : 1.0.3.1 / 10000309
- iOS : 1.0.4 / 10000401

## PR 포인트
- 컨텐츠 생성 / 수정 데이트 피커 상태 오류 수정
- 바텀시트 피커의 date, time 상태와 화면에 표시되는 date, time 상태 분리