### PR TITLE
[Fix] Notification Permission 거부 했을 때 프로필 생성 완료 불가능 오류 수정

### DIFF
--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateRoute.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateRoute.kt
@@ -13,6 +13,7 @@ import com.whatever.caramel.core.designsystem.util.HapticStyle
 import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.feature.profile.create.mvi.ProfileCreateIntent
 import com.whatever.caramel.feature.profile.create.mvi.ProfileCreateSideEffect
+import dev.icerock.moko.permissions.compose.BindEffect
 import dev.icerock.moko.permissions.compose.PermissionsControllerFactory
 import dev.icerock.moko.permissions.compose.rememberPermissionsControllerFactory
 import org.jetbrains.compose.resources.stringResource
@@ -42,6 +43,8 @@ internal fun ProfileCreateRoute(
     BackHandler {
         viewModel.intent(ProfileCreateIntent.ClickSystemNavigationBackButton)
     }
+
+    BindEffect(permissionsController = viewModel.permissionsController)
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateViewModel.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/ProfileCreateViewModel.kt
@@ -21,7 +21,7 @@ import dev.icerock.moko.permissions.notifications.REMOTE_NOTIFICATION
 class ProfileCreateViewModel(
     private val createUserProfileUseCase: CreateUserProfileUseCase,
     private val updateUserSettingUseCase: UpdateUserSettingUseCase,
-    private val permissionsController: PermissionsController,
+    val permissionsController: PermissionsController,
     savedStateHandle: SavedStateHandle,
     crashlytics: CaramelCrashlytics,
 ) : BaseViewModel<ProfileCreateState, ProfileCreateSideEffect, ProfileCreateIntent>(

--- a/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/di/Module.kt
+++ b/feature/profile/create/src/commonMain/kotlin/com/whatever/caramel/feature/profile/create/di/Module.kt
@@ -1,19 +1,10 @@
 package com.whatever.caramel.feature.profile.create.di
 
 import com.whatever.caramel.feature.profile.create.ProfileCreateViewModel
-import dev.icerock.moko.permissions.PermissionsController
-import org.koin.core.module.dsl.viewModel
+import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val profileCreateFeatureModule =
     module {
-        viewModel { (permissionsController: PermissionsController) ->
-            ProfileCreateViewModel(
-                savedStateHandle = get(),
-                createUserProfileUseCase = get(),
-                updateUserSettingUseCase = get(),
-                permissionsController = permissionsController,
-                crashlytics = get(),
-            )
-        }
+        viewModelOf(::ProfileCreateViewModel)
     }


### PR DESCRIPTION
## 관련 이슈
- closes #344 

## 작업한 내용
- PermissionsController 생명주기 동기화

## PR 포인트
- 문제 상황 및 해결 과정
  ```kotlin
  class ProfileCreateViewModel(
      ...
      private val permissionsController: PermissionsController,
      ...
  ) : BaseViewModel<...>(...) {
    ...
    private suspend fun checkNextStep() {
    when (currentState.currentStep) {
            ProfileCreateStep.NICKNAME -> { ... }
            ProfileCreateStep.NEED_TERMS -> {
                val userStatus =
                    createUserProfileUseCase(
                        nickname = currentState.nickname,
                        birthDay =
                            createDateString(
                                currentState.birthday.year,
                                currentState.birthday.month,
                                currentState.birthday.day,
                            ),
                        gender = currentState.gender,
                        agreementServiceTerms = currentState.isServiceTermChecked,
                        agreementPrivacyPolicy = currentState.isPersonalInfoTermChecked,
                    )

                updateUserSettingUseCase( // 사용자 권한 허용 여부를 불러오는 과정에서 오류 발생
                    notificationEnabled =
                        permissionsController.isPermissionGranted(
                            permission = Permission.REMOTE_NOTIFICATION,
                        ),
                )
                postSideEffect(ProfileCreateSideEffect.NavigateToStartDestination(userStatus = userStatus))
            }
        else -> { ... }
  }
  ```
  - 컴포저블 함수에 연결된 뷰모델에서 PermissionsController의 인스턴스에 접근하기 위해선 컴포저블과 생명주기를 동기화해야 합니다. 때문에 뷰모델에 주입된 PermissionsController 인스턴스를 그대로 ProfileCreateRoute에서 BindEffect로 동기화를 시켜줍니다.