### PR TITLE
[Fix] 홈 - 밸런스 게임 옵션 변경 시 상대가 골랐을 때 게임 카드 상태 변경

### DIFF
--- a/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/exception/code/BalanceGameErrorCode.kt
+++ b/core/domain/src/commonMain/kotlin/com/whatever/caramel/core/domain/exception/code/BalanceGameErrorCode.kt
@@ -1,0 +1,7 @@
+package com.whatever.caramel.core.domain.exception.code
+
+object BalanceGameErrorCode {
+    private const val PREFIX = "BGAME"
+
+    const val CAN_NOT_CHANGE_OPTION = PREFIX + "005"
+}

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.exception.CaramelException
 import com.whatever.caramel.core.domain.exception.ErrorUiType
+import com.whatever.caramel.core.domain.exception.code.BalanceGameErrorCode
 import com.whatever.caramel.core.domain.exception.code.CoupleErrorCode
 import com.whatever.caramel.core.domain.usecase.balanceGame.GetTodayBalanceGameUseCase
 import com.whatever.caramel.core.domain.usecase.balanceGame.SubmitBalanceGameChoiceUseCase
@@ -93,6 +94,9 @@ class HomeViewModel(
         super.handleClientException(throwable)
         if (throwable is CaramelException) {
             when (throwable.code) {
+                BalanceGameErrorCode.CAN_NOT_CHANGE_OPTION -> {
+                    launch { initBalanceGame() }
+                }
                 CoupleErrorCode.CAN_NOT_LOAD_DATA -> {
                     reduce {
                         copy(


### PR DESCRIPTION
## 작업한 내용
- 밸런스 게임 에러 코드 추가
- BGAME005 에러 발생 시 밸런스 게임 데이터 새로 고침