### PR TITLE
[Fix] iOS - 디바이스 고유 ID 획득 로직 수정

### DIFF
--- a/app-ios/iosApp.xcodeproj/project.pbxproj
+++ b/app-ios/iosApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		583FC0462DEBEB5A002005A1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 583FC0452DEBEB5A002005A1 /* Assets.xcassets */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
+		BA7980140AA16F90FE41A1E5 /* KeychainHelperBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7987553DCC66B90D63EEFB /* KeychainHelperBridge.swift */; };
 		BA798D050359A3FCD8D56DD7 /* FirebaseCrashlyticsBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA798D5911C08037AABB0C2E /* FirebaseCrashlyticsBridge.swift */; };
 		BAA2B7AB2D72DA330017F868 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = BAA2B7AA2D72DA330017F868 /* FirebaseAnalytics */; };
 		BAA2B7AD2D72DA330017F868 /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = BAA2B7AC2D72DA330017F868 /* FirebaseAnalyticsOnDeviceConversion */; };
@@ -50,6 +51,7 @@
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BA4C47392DEBF62200435A54 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		BA4C473A2DEBF62F00435A54 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		BA7987553DCC66B90D63EEFB /* KeychainHelperBridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KeychainHelperBridge.swift; path = keychainHelperBridge/KeychainHelperBridge.swift; sourceTree = "<group>"; };
 		BA798D5911C08037AABB0C2E /* FirebaseCrashlyticsBridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FirebaseCrashlyticsBridge.swift; path = firebaseCrashlyticsBridge/FirebaseCrashlyticsBridge.swift; sourceTree = "<group>"; };
 		E93275342DD225A7004AE2BF /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		E93275362DD225BB004AE2BF /* AppTrackingTransparency.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppTrackingTransparency.framework; path = System/Library/Frameworks/AppTrackingTransparency.framework; sourceTree = SDKROOT; };
@@ -96,6 +98,7 @@
 				7555FF7C242A565900829871 /* Products */,
 				7555FFB0242A642200829871 /* Frameworks */,
 				BA798D5911C08037AABB0C2E /* FirebaseCrashlyticsBridge.swift */,
+				BA7987553DCC66B90D63EEFB /* KeychainHelperBridge.swift */,
 			);
 			sourceTree = "<group>";
 			usesTabs = 0;
@@ -276,6 +279,7 @@
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 				E987BEBD2DEB63D200CE545C /* MessagingDelegate.swift in Sources */,
 				BA798D050359A3FCD8D56DD7 /* FirebaseCrashlyticsBridge.swift in Sources */,
+				BA7980140AA16F90FE41A1E5 /* KeychainHelperBridge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/app-ios/keychainHelperBridge/KeychainHelperBridge.swift
+++ b/app-ios/keychainHelperBridge/KeychainHelperBridge.swift
@@ -1,0 +1,50 @@
+//
+// Created by 함건형 on 2025. 8. 19..
+// Copyright (c) 2025 orgName. All rights reserved.
+//
+
+import Foundation
+import Security
+
+@objcMembers
+public class KeychainHelperBridge: NSObject {
+
+    private let service = "com.whatever.caramel.deviceid"
+
+    public func get(key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: kCFBooleanTrue as Any,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    public func set(_ key: String, value: String) {
+        let data = value.data(using: .utf8)!
+
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        let attrs: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+        SecItemAdd(attrs as CFDictionary, nil)
+    }
+
+}

--- a/core/remote/build.gradle.kts
+++ b/core/remote/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("caramel.kmp.ios")
     id("caramel.kotlin.serialization")
     alias(libs.plugins.ksp)
+    alias(libs.plugins.kmp.spm)
 }
 
 android.namespace = "com.whatever.caramel.core.remote"
@@ -47,6 +48,18 @@ kotlin {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
 
+    listOf(
+        iosX64(),
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach { iosTarget ->
+        iosTarget.compilations {
+            val main by getting {
+                cinterops.create("keychainHelperBridge")
+            }
+        }
+    }
+
     sourceSets {
         androidMain.dependencies {
             implementation(libs.ktor.client.okhttp)
@@ -73,4 +86,12 @@ dependencies {
     add("kspIosX64", libs.koin.ksp.compiler)
     add("kspIosArm64", libs.koin.ksp.compiler)
     add("kspIosSimulatorArm64", libs.koin.ksp.compiler)
+}
+
+
+swiftPackageConfig {
+    create("keychainHelperBridge") {
+        customPackageSourcePath = "../../app-ios"
+        minIos = "15.0"
+    }
 }

--- a/core/remote/src/iosMain/kotlin/com/whatever/caramel/core/remote/di/Module.ios.kt
+++ b/core/remote/src/iosMain/kotlin/com/whatever/caramel/core/remote/di/Module.ios.kt
@@ -4,6 +4,8 @@ import com.whatever.caramel.core.remote.network.config.DeviceIdProvider
 import com.whatever.caramel.core.remote.network.config.IOSDeviceIdProvider
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.darwin.Darwin
+import keychainHelperBridge.KeychainHelperBridge
+import kotlinx.cinterop.ExperimentalForeignApi
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
@@ -13,10 +15,13 @@ actual val networkClientEngineModule: Module
             single<HttpClientEngine> { Darwin.create() }
         }
 
+@OptIn(ExperimentalForeignApi::class)
 actual val deviceIdModule: Module
     get() =
         module {
             single<DeviceIdProvider> {
-                IOSDeviceIdProvider()
+                IOSDeviceIdProvider(
+                    keychainHelperBridge = KeychainHelperBridge()
+                )
             }
         }

--- a/core/remote/src/iosMain/kotlin/com/whatever/caramel/core/remote/network/config/IOSDeviceIdProvider.kt
+++ b/core/remote/src/iosMain/kotlin/com/whatever/caramel/core/remote/network/config/IOSDeviceIdProvider.kt
@@ -1,7 +1,26 @@
 package com.whatever.caramel.core.remote.network.config
 
-import platform.UIKit.UIDevice
+import keychainHelperBridge.KeychainHelperBridge
+import kotlinx.cinterop.ExperimentalForeignApi
 
-class IOSDeviceIdProvider : DeviceIdProvider {
-    override val deviceId = UIDevice.currentDevice.identifierForVendor?.UUIDString ?: "unknown"
+@OptIn(ExperimentalForeignApi::class)
+class IOSDeviceIdProvider(
+    private val keychainHelperBridge: KeychainHelperBridge,
+) : DeviceIdProvider {
+
+    override val deviceId: String
+        get() {
+            keychainHelperBridge.getWithKey(key = KEY)?.let { value ->
+                return value
+            }
+
+            val newId = platform.Foundation.NSUUID().UUIDString
+            keychainHelperBridge.set(key = KEY, value = newId)
+
+            return newId
+        }
+
+    companion object {
+        private const val KEY = "com.whatever.caramel"
+    }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #359 

## 작업한 내용
- KeychainHelperBridger 구현

## PR 포인트
- Keychain을 활용한 iOS 기기 고유 식별자
  - #359 이슈에서 iOS의 UUID 획득 시 특정 상황에 변경되던 문제가 있었습니다. 이를 해결하기 위해 기기마다 Keychain에 고유 키-값을 저장시켜 우리 앱에서 사용 가능한 고유 식별자 값을 생성하고 획득할수 있게 변경하였습니다. 해당 값이 지워지는 환경은 사용자가 직접 디바이스 환경 설정에서 '모든 데이터 초기화'를 해주지 않는 이상 생성된 키-값은 유지됩니다.