### PR TITLE
[QA] 스케쥴 -> 메모 변환 시 오류 수정

### DIFF
--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/repository/ScheduleRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/repository/ScheduleRepositoryImpl.kt
@@ -44,7 +44,7 @@ class ScheduleRepositoryImpl(
                 title = parameter.title,
                 description = parameter.description,
                 isCompleted = parameter.isCompleted,
-                startDateTime = parameter.dateTimeInfo?.startDateTime.toString(),
+                startDateTime = parameter.dateTimeInfo?.startDateTime?.toString(),
                 startTimeZone = parameter.dateTimeInfo?.startTimezone,
                 endDateTime = parameter.dateTimeInfo?.endDateTime?.toString(),
                 endTimeZone = parameter.dateTimeInfo?.endTimezone,


### PR DESCRIPTION
## 작업한 내용
- toString()을 확장함수가 아닌 override 메소드를 사용하도록 변경
- [스레드](https://whatever-xhr4427.slack.com/archives/C082BGJP546/p1757951101361169)에서의 예시가 잘못되어 있어 해당 PR만 확인해주시면 됩니다.