### PR TITLE
[QA] 캘린더 새로고침 시 Indicator가 유지되는 현상 수정

### DIFF
--- a/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarViewModel.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/whatever/caramel/feature/calendar/CalendarViewModel.kt
@@ -159,6 +159,7 @@ class CalendarViewModel(
     }
 
     private fun refreshCalendar() {
+        reduce { copy(isRefreshing = true) }
         getYearSchedules(
             year = currentState.year,
             isRefresh = true,


### PR DESCRIPTION
## 작업한 내용
- 캘린더 Pull To Refresh하면 Indicator가 사라지지 않는 현상 수정
  - `getYearSchedules`를 수정하며 isRefreshing 상태를 변경하는 부분이 누락되어 수정추가했습니다.