### PR TITLE
[Build] QA 빌드 타입 추가 및 빌드 타입 별 앱 생성 분기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ core/database/schemas
 
 # Xcode
 **/GoogleService-Info.plist
+**/GoogleService-Info-Qa.plist
 *.xcworkspace
 *.xcuserdata/
 !*.xcworkspace/contents.xcworkspacedata

--- a/app-ios/iosApp.xcodeproj/project.pbxproj
+++ b/app-ios/iosApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		E93275372DD225BB004AE2BF /* AppTrackingTransparency.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E93275362DD225BB004AE2BF /* AppTrackingTransparency.framework */; };
 		E97442F12DF2DAC400B9CDEE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E97442F02DF2DAC400B9CDEE /* Assets.xcassets */; };
 		E97442F32DF2DB2B00B9CDEE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E97442F22DF2DB2B00B9CDEE /* GoogleService-Info.plist */; };
+		E98165282EDF102D0015367C /* Qa.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = E98165272EDF102D0015367C /* Qa.xcconfig */; };
 		E987BEB22DEB080E00CE545C /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = E987BEB12DEB080E00CE545C /* FirebaseMessaging */; };
 		E987BEBD2DEB63D200CE545C /* MessagingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E987BEBC2DEB63D200CE545C /* MessagingDelegate.swift */; };
 		E987BEBF2DEB640800CE545C /* NotificationCenterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E987BEBE2DEB640800CE545C /* NotificationCenterDelegate.swift */; };
@@ -62,6 +63,7 @@
 		E96349E22D7C238E00F6BBF7 /* iosApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iosApp.entitlements; sourceTree = "<group>"; };
 		E97442F02DF2DAC400B9CDEE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E97442F22DF2DB2B00B9CDEE /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		E98165272EDF102D0015367C /* Qa.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Qa.xcconfig; sourceTree = "<group>"; };
 		E987BEBC2DEB63D200CE545C /* MessagingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingDelegate.swift; sourceTree = "<group>"; };
 		E987BEBE2DEB640800CE545C /* NotificationCenterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterDelegate.swift; sourceTree = "<group>"; };
 		E9A293E92D78E4930060A927 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 			children = (
 				BA4C47392DEBF62200435A54 /* Debug.xcconfig */,
 				BA4C473A2DEBF62F00435A54 /* Release.xcconfig */,
+				E98165272EDF102D0015367C /* Qa.xcconfig */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -221,6 +224,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E98165282EDF102D0015367C /* Qa.xcconfig in Resources */,
 				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
 				583FC0462DEBEB5A002005A1 /* Assets.xcassets in Resources */,
 				E97442F32DF2DB2B00B9CDEE /* GoogleService-Info.plist in Resources */,
@@ -434,6 +438,7 @@
 				INFOPLIST_FILE = iosApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "[Dev] Caramel";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				KOTLIN_FRAMEWORK_BUILD_TYPE = debug;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -477,6 +482,7 @@
 				INFOPLIST_FILE = iosApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Caramel;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				KOTLIN_FRAMEWORK_BUILD_TYPE = release;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -500,6 +506,107 @@
 			};
 			name = Release;
 		};
+		E98165202EDF0FDD0015367C /* Qa */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E98165272EDF102D0015367C /* Qa.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Qa;
+		};
+		E98165212EDF0FDD0015367C /* Qa */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E98165272EDF102D0015367C /* Qa.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 10010204;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AR6HWFH5V3;
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../app/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Caramel;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				KOTLIN_FRAMEWORK_BUILD_TYPE = release;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.1.2;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					app,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.whatever.caramel;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.whatever.caramel";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Qa;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -508,6 +615,7 @@
 			buildConfigurations = (
 				7555FFA3242A565B00829871 /* Debug */,
 				7555FFA4242A565B00829871 /* Release */,
+				E98165202EDF0FDD0015367C /* Qa */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -517,6 +625,7 @@
 			buildConfigurations = (
 				7555FFA6242A565B00829871 /* Debug */,
 				7555FFA7242A565B00829871 /* Release */,
+				E98165212EDF0FDD0015367C /* Qa */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/app-ios/iosApp.xcodeproj/project.pbxproj
+++ b/app-ios/iosApp.xcodeproj/project.pbxproj
@@ -21,8 +21,9 @@
 		BAA2B7B12D72DA330017F868 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = BAA2B7B02D72DA330017F868 /* FirebaseCrashlytics */; };
 		E93275352DD225A7004AE2BF /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E93275342DD225A7004AE2BF /* AdSupport.framework */; };
 		E93275372DD225BB004AE2BF /* AppTrackingTransparency.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E93275362DD225BB004AE2BF /* AppTrackingTransparency.framework */; };
+		E962CE8D2EE05011008E1284 /* GoogleService-Info-Qa.plist in Resources */ = {isa = PBXBuildFile; fileRef = E962CE8A2EE04C11008E1284 /* GoogleService-Info-Qa.plist */; };
+		E962CE8E2EE05011008E1284 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E97442F22DF2DB2B00B9CDEE /* GoogleService-Info.plist */; };
 		E97442F12DF2DAC400B9CDEE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E97442F02DF2DAC400B9CDEE /* Assets.xcassets */; };
-		E97442F32DF2DB2B00B9CDEE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E97442F22DF2DB2B00B9CDEE /* GoogleService-Info.plist */; };
 		E98165282EDF102D0015367C /* Qa.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = E98165272EDF102D0015367C /* Qa.xcconfig */; };
 		E987BEB22DEB080E00CE545C /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = E987BEB12DEB080E00CE545C /* FirebaseMessaging */; };
 		E987BEBD2DEB63D200CE545C /* MessagingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E987BEBC2DEB63D200CE545C /* MessagingDelegate.swift */; };
@@ -60,6 +61,7 @@
 		BA798D5911C08037AABB0C2E /* FirebaseCrashlyticsBridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FirebaseCrashlyticsBridge.swift; path = firebaseCrashlyticsBridge/FirebaseCrashlyticsBridge.swift; sourceTree = "<group>"; };
 		E93275342DD225A7004AE2BF /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		E93275362DD225BB004AE2BF /* AppTrackingTransparency.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppTrackingTransparency.framework; path = System/Library/Frameworks/AppTrackingTransparency.framework; sourceTree = SDKROOT; };
+		E962CE8A2EE04C11008E1284 /* GoogleService-Info-Qa.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Qa.plist"; sourceTree = "<group>"; };
 		E96349E22D7C238E00F6BBF7 /* iosApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iosApp.entitlements; sourceTree = "<group>"; };
 		E97442F02DF2DAC400B9CDEE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E97442F22DF2DB2B00B9CDEE /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 		7555FF7D242A565900829871 /* iosApp */ = {
 			isa = PBXGroup;
 			children = (
+				E962CE8A2EE04C11008E1284 /* GoogleService-Info-Qa.plist */,
 				E97442F22DF2DB2B00B9CDEE /* GoogleService-Info.plist */,
 				E97442F02DF2DAC400B9CDEE /* Assets.xcassets */,
 				BA4C473D2DEBF67700435A54 /* Configuration */,
@@ -170,6 +173,7 @@
 				7555FF79242A565900829871 /* Resources */,
 				7555FFB4242A642300829871 /* Embed Frameworks */,
 				BABA8A5E2D7330F300E0C23B /* ShellScript */,
+				E962CE8C2EE04C52008E1284 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -224,10 +228,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E962CE8D2EE05011008E1284 /* GoogleService-Info-Qa.plist in Resources */,
+				E962CE8E2EE05011008E1284 /* GoogleService-Info.plist in Resources */,
 				E98165282EDF102D0015367C /* Qa.xcconfig in Resources */,
 				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
 				583FC0462DEBEB5A002005A1 /* Assets.xcassets in Resources */,
-				E97442F32DF2DB2B00B9CDEE /* GoogleService-Info.plist in Resources */,
 				E97442F12DF2DAC400B9CDEE /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -275,6 +280,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
+		};
+		E962CE8C2EE04C52008E1284 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\nCONFIG_NAME=\"${CONFIGURATION}\"\n\nBASE_PLIST=\"${PROJECT_DIR}/iosApp/GoogleService-Info.plist\"\nQA_PLIST=\"${PROJECT_DIR}/iosApp/GoogleService-Info-Qa.plist\"\n\nDEST_PLIST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleService-Info.plist\"\n\necho \"CONFIGURATION = ${CONFIG_NAME}\"\n\nif [ \"${CONFIG_NAME}\" = \"Qa\" ]; then\n  echo \"Using QA Firebase config: ${QA_PLIST}\"\n  SRC_PLIST=\"${QA_PLIST}\"\nelse\n  echo \"Using Debug/Release Firebase config: ${BASE_PLIST}\"\n  SRC_PLIST=\"${BASE_PLIST}\"\nfi\n\nif [ -f \"${SRC_PLIST}\" ]; then\n  cp \"${SRC_PLIST}\" \"${DEST_PLIST}\"\n  echo \"Copied ${SRC_PLIST} -> ${DEST_PLIST}\"\nelse\n  echo \"❌ Firebase config file not found: ${SRC_PLIST}\"\n  exit 1\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -351,6 +373,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Caramel-Dev";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -408,6 +431,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Caramel;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -422,6 +446,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BA4C47392DEBF62200435A54 /* Debug.xcconfig */;
 			buildSettings = {
+				APP_DISPLAY_NAME = "Caramel-Dev";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -436,7 +461,7 @@
 					"$(SRCROOT)/../app/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
 				);
 				INFOPLIST_FILE = iosApp/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "[Dev] Caramel";
+				INFOPLIST_KEY_CFBundleDisplayName = "Caramel-Dev";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				KOTLIN_FRAMEWORK_BUILD_TYPE = debug;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -466,6 +491,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BA4C473A2DEBF62F00435A54 /* Release.xcconfig */;
 			buildSettings = {
+				APP_DISPLAY_NAME = Caramel;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
@@ -553,6 +579,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Caramel-QA";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -567,6 +594,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E98165272EDF102D0015367C /* Qa.xcconfig */;
 			buildSettings = {
+				APP_DISPLAY_NAME = "Caramel-QA";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
@@ -581,7 +609,7 @@
 					"$(SRCROOT)/../app/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
 				);
 				INFOPLIST_FILE = iosApp/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Caramel;
+				INFOPLIST_KEY_CFBundleDisplayName = "Caramel-Qa";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				KOTLIN_FRAMEWORK_BUILD_TYPE = release;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -594,10 +622,10 @@
 					"-framework",
 					app,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.whatever.caramel;
+				PRODUCT_BUNDLE_IDENTIFIER = com.whatever.caramel.qa;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.whatever.caramel";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.whatever.caramel.qa";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/app-ios/iosApp/Info.plist
+++ b/app-ios/iosApp/Info.plist
@@ -14,8 +14,8 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>Caramel</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(APP_DISPLAY_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>

--- a/app-ios/iosApp/Info.plist
+++ b/app-ios/iosApp/Info.plist
@@ -43,8 +43,6 @@
 	<string>10010204</string>
 	<key>CaramelBaseUrl</key>
 	<string>$(CARAMEL_BASE_URL)</string>
-	<key>CaramelSampleUrl</key>
-	<string>$(CARAMEL_SAMPLE_URL)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>KakaoNativeAppKey</key>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,6 +133,7 @@ android {
             isMinifyEnabled = false
             isDebuggable = false
             signingConfig = signingConfigs.getByName("release")
+            resValue("string", "app_name", "Caramel")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
@@ -142,6 +143,7 @@ android {
         debug {
             isMinifyEnabled = false
             isDebuggable = true
+            resValue("string", "app_name", "Caramel-Dev")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
@@ -150,8 +152,10 @@ android {
 
         getByName("qa") {
             isMinifyEnabled = false
+            applicationIdSuffix = ".qa"
             versionNameSuffix = "-qa"
             signingConfig = signingConfigs.getByName("release")
+            resValue("string", "app_name", "Caramel-QA")
         }
     }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -147,5 +147,11 @@ android {
                 "proguard-rules.pro",
             )
         }
+
+        getByName("qa") {
+            isMinifyEnabled = false
+            versionNameSuffix = "-qa"
+            signingConfig = signingConfigs.getByName("release")
+        }
     }
 }

--- a/build-logic/convention/src/main/java/com/whatever/caramel/buildlogic/convention/AndroidApplicationPlugin.kt
+++ b/build-logic/convention/src/main/java/com/whatever/caramel/buildlogic/convention/AndroidApplicationPlugin.kt
@@ -2,15 +2,12 @@ package com.whatever.caramel.buildlogic.convention
 
 import com.whatever.caramel.buildlogic.convention.extension.android
 import com.whatever.caramel.buildlogic.convention.extension.androidApplication
+import com.whatever.caramel.buildlogic.convention.extension.createQaBuildType
 import com.whatever.caramel.buildlogic.convention.extension.libs
-import com.whatever.caramel.buildlogic.convention.extension.plugin
 import com.whatever.caramel.buildlogic.convention.extension.version
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.apply
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.konan.properties.Properties
 
 @Suppress("unused")
 class AndroidApplicationPlugin : Plugin<Project>{
@@ -47,6 +44,7 @@ class AndroidApplicationPlugin : Plugin<Project>{
                         sourceCompatibility = JavaVersion.VERSION_17
                         targetCompatibility = JavaVersion.VERSION_17
                     }
+                    createQaBuildType()
                 }
             }
         }

--- a/build-logic/convention/src/main/java/com/whatever/caramel/buildlogic/convention/KmpAndroidPlugin.kt
+++ b/build-logic/convention/src/main/java/com/whatever/caramel/buildlogic/convention/KmpAndroidPlugin.kt
@@ -2,14 +2,11 @@ package com.whatever.caramel.buildlogic.convention
 
 import com.whatever.caramel.buildlogic.convention.extension.android
 import com.whatever.caramel.buildlogic.convention.extension.configureAndroid
-import com.whatever.caramel.buildlogic.convention.extension.debugImplementation
+import com.whatever.caramel.buildlogic.convention.extension.createQaBuildType
 import com.whatever.caramel.buildlogic.convention.extension.kotlin
-import com.whatever.caramel.buildlogic.convention.extension.library
 import com.whatever.caramel.buildlogic.convention.extension.libraryAndroidOptions
-import com.whatever.caramel.buildlogic.convention.extension.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.dependencies
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 @Suppress("unused")
@@ -34,6 +31,7 @@ class KmpAndroidPlugin : Plugin<Project> {
             }
             android {
                 configureAndroid()
+                createQaBuildType()
             }
         }
     }

--- a/build-logic/convention/src/main/java/com/whatever/caramel/buildlogic/convention/extension/AndroidGradleDsl.kt
+++ b/build-logic/convention/src/main/java/com/whatever/caramel/buildlogic/convention/extension/AndroidGradleDsl.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.buildlogic.convention.extension
 
 
+import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.TestedExtension
@@ -43,6 +44,15 @@ fun Project.configureAndroid() {
         compileOptions {
             sourceCompatibility = JavaVersion.VERSION_17
             targetCompatibility = JavaVersion.VERSION_17
+        }
+    }
+}
+
+fun TestedExtension.createQaBuildType() {
+    buildTypes {
+        maybeCreate("qa").apply {
+            initWith(getByName("release"))
+            isDebuggable = true
         }
     }
 }

--- a/core/remote/build.gradle.kts
+++ b/core/remote/build.gradle.kts
@@ -20,6 +20,7 @@ android {
         val properties = Properties().apply { load(rootProject.file("local.properties").inputStream()) }
         val debugUrl = "CARAMEL_DEBUG_URL"
         val releaseUrl = "CARAMEL_RELEASE_URL"
+        val qaUrl = "CARAMEL_QA_URL"
 
         fun getEnvOrProp(key: String): String = System.getenv(key) ?: properties.getProperty(key)
 
@@ -38,6 +39,16 @@ android {
                 "String",
                 "BASE_URL",
                 "\"${properties.getProperty(debugUrl)}\"",
+            )
+        }
+
+        getByName("qa") {
+            isMinifyEnabled = false
+
+            buildConfigField(
+                "String",
+                "BASE_URL",
+                "\"${getEnvOrProp(key = qaUrl)}\"",
             )
         }
     }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -7,6 +7,12 @@ plugins {
 
 android.namespace = "com.whatever.caramel.core.ui"
 
+android {
+    buildFeatures {
+        buildConfig = true
+    }
+}
+
 kotlin {
     sourceSets {
         commonMain.dependencies {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -72,8 +72,7 @@ platform :ios do
       scheme: "iosApp",
       export_method: "app-store",
       project: "app-ios/iosApp.xcodeproj",
-      configuration: "Release",
-      xcargs: "CARAMEL_BASE_URL=#{ENV["CARAMEL_RELEASE_URL"]}"
+      configuration: "Qa",
     )
 
     api_key = app_store_connect_api_key(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,7 +26,7 @@ platform :android do
 
     gradle(
       task: "bundle",
-      build_type: "Release",
+      build_type: "Qa",
       project_dir: "./"
     )
 

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,6 +1,7 @@
 git_url("git@github.com:whatever-x/ios-match")
 type("appstore")
-app_identifier(
-    ["com.whatever.caramel"]
-)
+app_identifier([
+    "com.whatever.caramel",
+    "com.whatever.caramel.qa"
+])
 username("whatever2024.team@gmail.com")


### PR DESCRIPTION
## 작업한 내용
- 플랫폼별 QA 빌드 타입 추가
- 빌드 타입 별 앱 생성 분기 처리

## PR 포인트
- Android 관련 로컬 확인 사항
  - `local.properties`
  - `google-services.json`
- iOS 관련 로컬 확인 사항
  - `Google-Service-Info-Qa.plist`
  - `Qa.xcconfig`
  - Qa 용 프로버저닝
- iOS QA 용 프로버저닝 추가
  - fastlane의 match 기능을 활용하시면 됩니다.
  ```
  // 기존 Release, Debug 용 프로버저닝 있을 경우 Qa 만 다운로드
  fastlane match appstore --app_identifier "com.whatever.caramel.qa"

  // 모두 다운 로드 해야할 경우
  fastlane match appstore // Release, Qa 다운로드
  fastlane match development // Debug 다운로드
  ```
  - Qa 환경이 Release 환경에 맞춰졌기 때문에 appstore 명령어를 사용할 경우 모두 다운로드 됩니다. (Testflight 정책에 따라 Release 환경이 강제로...)