### PR TITLE
[Fix] 토큰 재생성 실패 처리 개선

### DIFF
--- a/core/analytics/src/androidMain/AndroidManifest.xml
+++ b/core/analytics/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+	xmlns:android="http://schemas.android.com/apk/res/android">
+
+	<uses-permission
+		android:name="android.permission.INTERNET" />
+	<uses-permission
+		android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<uses-permission
+		android:name="android.permission.WAKE_LOCK" />
+
+</manifest>

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/interceptor/TokenInterceptorImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/interceptor/TokenInterceptorImpl.kt
@@ -24,34 +24,35 @@ class TokenInterceptorImpl(
      * @author ham2174
      * @since 2025.03.15
      */
-    override suspend fun refresh(): Boolean = refreshMutex.withLock {
-        try {
-            val accessToken = localTokenDataSource.fetchAccessToken()
-            val refreshToken = localTokenDataSource.fetchRefreshToken()
+    override suspend fun refresh(): Boolean =
+        refreshMutex.withLock {
+            try {
+                val accessToken = localTokenDataSource.fetchAccessToken()
+                val refreshToken = localTokenDataSource.fetchRefreshToken()
 
-            if (accessToken.isNotEmpty() && refreshToken.isNotEmpty()) {
-                val response =
-                    remoteAuthDataSource.refresh(
-                        request =
-                            ServiceTokenDto(
-                                accessToken = accessToken,
-                                refreshToken = refreshToken,
-                            ),
+                if (accessToken.isNotEmpty() && refreshToken.isNotEmpty()) {
+                    val response =
+                        remoteAuthDataSource.refresh(
+                            request =
+                                ServiceTokenDto(
+                                    accessToken = accessToken,
+                                    refreshToken = refreshToken,
+                                ),
+                        )
+
+                    localTokenDataSource.saveToken(
+                        accessToken = response.accessToken,
+                        refreshToken = response.refreshToken,
                     )
 
-                localTokenDataSource.saveToken(
-                    accessToken = response.accessToken,
-                    refreshToken = response.refreshToken,
-                )
-
-                return true
-            } else {
+                    return true
+                } else {
+                    // @ham2174 TODO : 로그아웃 API 호출
+                    return false
+                }
+            } catch (e: Exception) {
                 // @ham2174 TODO : 로그아웃 API 호출
                 return false
             }
-        } catch (e: Exception) {
-            // @ham2174 TODO : 로그아웃 API 호출
-            return false
         }
-    }
 }

--- a/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/interceptor/TokenInterceptorImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/whatever/caramel/core/data/interceptor/TokenInterceptorImpl.kt
@@ -4,11 +4,15 @@ import com.whatever.caramel.core.datastore.datasource.LocalTokenDataSource
 import com.whatever.caramel.core.remote.datasource.RemoteAuthDataSource
 import com.whatever.caramel.core.remote.dto.auth.ServiceTokenDto
 import com.whatever.caramel.core.remote.network.interceptor.TokenInterceptor
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class TokenInterceptorImpl(
     private val localTokenDataSource: LocalTokenDataSource,
     private val remoteAuthDataSource: RemoteAuthDataSource,
 ) : TokenInterceptor {
+    private val refreshMutex = Mutex()
+
     override suspend fun getAccessToken(): String = localTokenDataSource.fetchAccessToken()
 
     override suspend fun getRefreshToken(): String = localTokenDataSource.fetchRefreshToken()
@@ -20,7 +24,7 @@ class TokenInterceptorImpl(
      * @author ham2174
      * @since 2025.03.15
      */
-    override suspend fun refresh(): Boolean {
+    override suspend fun refresh(): Boolean = refreshMutex.withLock {
         try {
             val accessToken = localTokenDataSource.fetchAccessToken()
             val refreshToken = localTokenDataSource.fetchRefreshToken()

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/datasource/RemoteAuthDataSourceImpl.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/datasource/RemoteAuthDataSourceImpl.kt
@@ -43,7 +43,7 @@ internal class RemoteAuthDataSourceImpl(
             }.getBody()
 
     override suspend fun refreshV2(request: ServiceTokenDto): UserSessionRefreshResponse =
-        authClient
+        defaultClient
             .post("$BASE_AUTH_V2_URL/refresh") {
                 setBody(body = request)
             }.getBody()

--- a/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/di/Module.kt
+++ b/core/remote/src/commonMain/kotlin/com/whatever/caramel/core/remote/di/Module.kt
@@ -29,6 +29,7 @@ import com.whatever.caramel.core.remote.network.config.addDeviceIdHeader
 import com.whatever.caramel.core.remote.network.config.addTimeZoneHeader
 import com.whatever.caramel.core.remote.network.config.caramelDefaultRequest
 import com.whatever.caramel.core.remote.network.config.caramelResponseValidator
+import com.whatever.caramel.core.remote.network.exception.CaramelNetworkException
 import com.whatever.caramel.core.remote.network.interceptor.TokenInterceptor
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.auth.Auth
@@ -77,10 +78,22 @@ val networkModule =
                                 if (accessToken.isNotEmpty() && refreshToken.isNotEmpty()) {
                                     BearerTokens(accessToken, refreshToken)
                                 } else {
-                                    null
+                                    throw CaramelNetworkException(
+                                        code = "AUTH002",
+                                        debugMessage = "토큰 재생성이 실패하였습니다.",
+                                        message = "인증 정보가 만료되었습니다.",
+                                        description = null,
+                                        errorUiType = "TOAST",
+                                    )
                                 }
                             } else {
-                                null
+                                throw CaramelNetworkException(
+                                    code = "AUTH002",
+                                    debugMessage = "토큰 재생성이 실패하였습니다.",
+                                    message = "인증 정보가 만료되었습니다.",
+                                    description = null,
+                                    errorUiType = "TOAST",
+                                )
                             }
                         }
                     }

--- a/core/testing/src/commonMain/kotlin/com/whatever/caramel/core/testing/factory/AuthTestFactory.kt
+++ b/core/testing/src/commonMain/kotlin/com/whatever/caramel/core/testing/factory/AuthTestFactory.kt
@@ -1,7 +1,7 @@
 package com.whatever.caramel.core.testing.factory
 
-import com.whatever.caramel.core.domain.vo.auth.AuthToken
 import com.whatever.caramel.core.domain.vo.auth.AuthResult
+import com.whatever.caramel.core.domain.vo.auth.AuthToken
 import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.core.testing.constants.TestAuthInfo
 import com.whatever.caramel.core.testing.constants.TestCoupleInfo

--- a/core/testing/src/commonMain/kotlin/com/whatever/caramel/core/testing/factory/AuthTestFactory.kt
+++ b/core/testing/src/commonMain/kotlin/com/whatever/caramel/core/testing/factory/AuthTestFactory.kt
@@ -1,7 +1,7 @@
 package com.whatever.caramel.core.testing.factory
 
 import com.whatever.caramel.core.domain.vo.auth.AuthToken
-import com.whatever.caramel.core.domain.vo.auth.UserAuth
+import com.whatever.caramel.core.domain.vo.auth.AuthResult
 import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.core.testing.constants.TestAuthInfo
 import com.whatever.caramel.core.testing.constants.TestCoupleInfo
@@ -21,29 +21,26 @@ object AuthTestFactory {
         )
 
     fun createSingleUserAuth() =
-        UserAuth(
+        AuthResult(
             coupleId = null,
+            userId = TestUserInfo.TEST_USER_ID,
             userStatus = UserStatus.SINGLE,
-            nickname = TestUserInfo.TEST_USER_NICKNAME,
-            birthday = TestUserInfo.TEST_BIRTH_DAY,
             authToken = createValidToken(),
         )
 
     fun createNewUserAuth() =
-        UserAuth(
+        AuthResult(
             coupleId = null,
+            userId = TestUserInfo.TEST_USER_ID,
             userStatus = UserStatus.NEW,
-            nickname = null,
-            birthday = null,
             authToken = createValidToken(),
         )
 
     fun createCoupleUserAuth() =
-        UserAuth(
+        AuthResult(
             coupleId = TestCoupleInfo.TEST_COUPLE_ID,
+            userId = TestUserInfo.TEST_USER_ID,
             userStatus = UserStatus.COUPLED,
-            nickname = TestUserInfo.TEST_USER_NICKNAME,
-            birthday = TestUserInfo.TEST_BIRTH_DAY,
             authToken = createValidToken(),
         )
 }

--- a/core/testing/src/commonMain/kotlin/com/whatever/caramel/core/testing/factory/UserTestFactory.kt
+++ b/core/testing/src/commonMain/kotlin/com/whatever/caramel/core/testing/factory/UserTestFactory.kt
@@ -1,7 +1,6 @@
 package com.whatever.caramel.core.testing.factory
 
 import com.whatever.caramel.core.domain.entity.User
-import com.whatever.caramel.core.domain.vo.user.UserMetaData
 import com.whatever.caramel.core.domain.vo.user.UserProfile
 import com.whatever.caramel.core.domain.vo.user.UserStatus
 import com.whatever.caramel.core.testing.constants.TestUserInfo
@@ -16,11 +15,6 @@ object UserTestFactory {
                     nickName = TestUserInfo.TEST_USER_NICKNAME,
                     birthday = TestUserInfo.TEST_BIRTH_DAY,
                     gender = TestUserInfo.TEST_USER_GENDER,
-                ),
-            userMetaData =
-                UserMetaData(
-                    agreementServiceTerms = true,
-                    agreementPrivacyPolicy = true,
                 ),
         )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ org.gradle.configuration-cache=true
 #Kotlin
 kotlin.code.style=official
 kotlin.mpp.enableCInteropCommonization=true
+spmforkmp.disableStartupFile=true
 
 #Build target ignore
 kotlin.native.ignoreDisabledTargets=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,9 +8,9 @@ version-name = "1.1.1" # major(1), minor(1), patch(1)
 
 # Multiplatform
 compose = "1.9.3"
-kotlin = "2.2.0"
-ksp = "2.2.0-2.0.2"
-jetbrainsKotlinJvm = "2.2.0"
+kotlin = "2.2.21"
+ksp = "2.2.21-2.0.4"
+jetbrainsKotlinJvm = "2.2.21"
 
 # androidX
 androidx-core-ktx = "1.16.0"
@@ -58,7 +58,7 @@ kakao = "2.22.0"
 apps-flyer = "6.17.3"
 
 # Utility
-kmp-spm = "1.1.0"
+kmp-spm = "1.4.10"
 play-review = "2.0.2"
 
 # AD


### PR DESCRIPTION
## 작업한 내용
- Gradle Sync 시 발생하던 spm4kmp / Kotlin Native 호환성 문제 해결
- `refreshTokens` 실패 시 `null` 반환 대신 `CaramelNetworkException` 전달
- `refreshV2` API 호출 클라이언트를 `authClient`에서 `defaultClient`로 변경
- `TokenInterceptor` refresh 로직에 `Mutex` 적용

## PR 포인트
- 토큰 재생성 실패 처리
  - refresh 실패 또는 저장된 토큰이 비어있는 경우 `AUTH002` 코드와 `TOAST` 타입의 네트워크 예외를 전달하도록 수정했습니다.
  - `refreshTokens`에서 `null`을 반환해 재호출 흐름이 모호해지는 대신, 명시적으로 실패를 전파합니다.
- refresh API 클라이언트 분리
  - `refreshV2` 호출이 `Auth` 플러그인이 설치된 `authClient`를 다시 타지 않도록 `defaultClient`를 사용하게 변경했습니다.
- 토큰 재생성 동시성 제한
  - 여러 요청이 동시에 401을 받는 상황에서 refresh API와 토큰 저장 로직이 동시에 실행되지 않도록 `Mutex.withLock`을 적용했습니다.

## 테스트
- `./gradlew :app:resolveIdeDependencies --stacktrace`
- `./gradlew :app:assembleDebug --stacktrace`
- `./gradlew :core:remote:compileDebugKotlinAndroid --stacktrace`
- `./gradlew :core:data:compileDebugKotlinAndroid --stacktrace`