### PR TITLE
[Fix] 광고 배너 뷰 재사용 개선

### DIFF
--- a/core/ui/src/androidMain/kotlin/com/whatever/caramel/core/ui/admob/GoogleAdBannerView.android.kt
+++ b/core/ui/src/androidMain/kotlin/com/whatever/caramel/core/ui/admob/GoogleAdBannerView.android.kt
@@ -3,6 +3,9 @@
 package com.whatever.caramel.core.ui.admob
 
 import android.Manifest
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
 import androidx.annotation.RequiresPermission
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -11,7 +14,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.google.android.gms.ads.AdListener
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
@@ -33,7 +38,14 @@ internal actual fun GoogleAdBannerView(
 ) {
     AndroidView(
         modifier = modifier,
-        factory = { bannerState.adView },
+        factory = {
+            bannerState.adView.detachFromParent()
+            bannerState.adView
+        },
+        onReset = {
+            // LazyColumn 내부에서 AdView를 재사용해 스크롤 시 광고 재로딩을 줄이기 위한 빈 람다 생성
+        },
+        onRelease = { adView -> adView.detachFromParent() },
     )
 }
 
@@ -49,52 +61,75 @@ actual fun rememberGoogleAdBannerState(
     bannerType: GoogleAdBannerType,
 ): GoogleAdBannerState {
     val context = LocalContext.current
-    val bannerSize =
-        when (bannerType) {
-            is GoogleAdBannerType.InlineAdaptive -> {
-                AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(context, bannerType.width)
-            }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val adView =
+        remember(adUnitId, bannerType) {
+            createAdView(
+                context = context,
+                adUnitId = adUnitId,
+                bannerType = bannerType,
+            )
+        }
 
-            is GoogleAdBannerType.AnchoredAdaptive -> {
-                if (bannerType.width != SCREEN_FULL_WIDTH) {
-                    AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, bannerType.width)
-                } else {
-                    AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, AdSize.FULL_WIDTH)
+    DisposableEffect(adView, lifecycleOwner) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                when (event) {
+                    Lifecycle.Event.ON_RESUME -> adView.resume()
+                    Lifecycle.Event.ON_PAUSE -> adView.pause()
+                    else -> Unit
                 }
             }
-        }
+        lifecycleOwner.lifecycle.addObserver(observer)
 
-    val adView =
-        remember {
-            AdView(context).apply {
-                this.adListener =
-                    object : AdListener() {
-                        override fun onAdFailedToLoad(p0: LoadAdError) {
-                            super.onAdFailedToLoad(p0)
-                            // TODO : 배너 배치 실패 시 Crash 로그 수집
-                        }
-                    }
-                this.adUnitId = adUnitId
-                setAdSize(bannerSize)
-                loadAd(AdRequest.Builder().build())
-            }
-        }
-
-    LifecycleResumeEffect(adView) {
-        adView.resume()
-
-        onPauseOrDispose {
-            adView.pause()
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 
     DisposableEffect(adView) {
         onDispose {
+            adView.detachFromParent()
             adView.destroy()
         }
     }
 
-    return GoogleAdBannerState(
-        adView = adView,
-    )
+    return GoogleAdBannerState(adView = adView)
+}
+
+private fun createAdView(
+    context: Context,
+    adUnitId: String,
+    bannerType: GoogleAdBannerType,
+): AdView {
+    val adSize = when (bannerType) {
+        is GoogleAdBannerType.InlineAdaptive -> {
+            AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(context, bannerType.width)
+        }
+
+        is GoogleAdBannerType.AnchoredAdaptive -> {
+            if (bannerType.width != SCREEN_FULL_WIDTH) {
+                AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, bannerType.width)
+            } else {
+                AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, AdSize.FULL_WIDTH)
+            }
+        }
+    }
+
+    return AdView(context).apply {
+        adListener =
+            object : AdListener() {
+                override fun onAdFailedToLoad(p0: LoadAdError) {
+                    super.onAdFailedToLoad(p0)
+                    // TODO : 배너 배치 실패 시 Crash 로그 수집
+                }
+            }
+        this.adUnitId = adUnitId
+        setAdSize(adSize)
+        loadAd(AdRequest.Builder().build())
+    }
+}
+
+private fun View.detachFromParent() {
+    (parent as? ViewGroup)?.removeView(this)
 }

--- a/core/ui/src/androidMain/kotlin/com/whatever/caramel/core/ui/admob/GoogleAdBannerView.android.kt
+++ b/core/ui/src/androidMain/kotlin/com/whatever/caramel/core/ui/admob/GoogleAdBannerView.android.kt
@@ -103,19 +103,20 @@ private fun createAdView(
     adUnitId: String,
     bannerType: GoogleAdBannerType,
 ): AdView {
-    val adSize = when (bannerType) {
-        is GoogleAdBannerType.InlineAdaptive -> {
-            AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(context, bannerType.width)
-        }
+    val adSize =
+        when (bannerType) {
+            is GoogleAdBannerType.InlineAdaptive -> {
+                AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(context, bannerType.width)
+            }
 
-        is GoogleAdBannerType.AnchoredAdaptive -> {
-            if (bannerType.width != SCREEN_FULL_WIDTH) {
-                AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, bannerType.width)
-            } else {
-                AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, AdSize.FULL_WIDTH)
+            is GoogleAdBannerType.AnchoredAdaptive -> {
+                if (bannerType.width != SCREEN_FULL_WIDTH) {
+                    AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, bannerType.width)
+                } else {
+                    AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, AdSize.FULL_WIDTH)
+                }
             }
         }
-    }
 
     return AdView(context).apply {
         adListener =

--- a/core/ui/src/androidMain/kotlin/com/whatever/caramel/core/ui/admob/GoogleAdBannerView.android.kt
+++ b/core/ui/src/androidMain/kotlin/com/whatever/caramel/core/ui/admob/GoogleAdBannerView.android.kt
@@ -97,6 +97,7 @@ actual fun rememberGoogleAdBannerState(
     return GoogleAdBannerState(adView = adView)
 }
 
+@RequiresPermission(Manifest.permission.INTERNET)
 private fun createAdView(
     context: Context,
     adUnitId: String,

--- a/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/admob/GoogleAdBannerView.kt
+++ b/core/ui/src/commonMain/kotlin/com/whatever/caramel/core/ui/admob/GoogleAdBannerView.kt
@@ -4,13 +4,7 @@ package com.whatever.caramel.core.ui.admob
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
-
-val LocalHomeGoogleAdBanner =
-    staticCompositionLocalOf<GoogleAdBannerState> {
-        error("No HomeGoogleAdBanner provided")
-    }
 
 /**
  * 광고 Unit Id 모음

--- a/core/ui/src/iosMain/kotlin/com/whatever/caramel/core/ui/admob/GoogleAdBannerView.ios.kt
+++ b/core/ui/src/iosMain/kotlin/com/whatever/caramel/core/ui/admob/GoogleAdBannerView.ios.kt
@@ -57,7 +57,7 @@ actual fun rememberGoogleAdBannerState(
     bannerType: GoogleAdBannerType,
 ): GoogleAdBannerState {
     val rootViewController = LocalUIViewController.current
-    val delegate = GoogleAdBannerViewDelegate()
+    val delegate = remember { GoogleAdBannerViewDelegate() }
     val adSize =
         when (bannerType) {
             is GoogleAdBannerType.InlineAdaptive -> {
@@ -75,7 +75,7 @@ actual fun rememberGoogleAdBannerState(
         }
 
     val bannerView =
-        remember {
+        remember(adUnitId, bannerType, rootViewController) {
             GADBannerView().apply {
                 this.adSize = adSize
                 this.adUnitID = adUnitId
@@ -90,6 +90,7 @@ actual fun rememberGoogleAdBannerState(
     DisposableEffect(bannerView) {
         onDispose {
             bannerView.delegate = null
+            bannerView.rootViewController = null
         }
     }
 

--- a/core/ui/src/iosMain/kotlin/com/whatever/caramel/core/ui/admob/GoogleAdBannerView.ios.kt
+++ b/core/ui/src/iosMain/kotlin/com/whatever/caramel/core/ui/admob/GoogleAdBannerView.ios.kt
@@ -57,7 +57,10 @@ actual fun rememberGoogleAdBannerState(
     bannerType: GoogleAdBannerType,
 ): GoogleAdBannerState {
     val rootViewController = LocalUIViewController.current
-    val delegate = remember { GoogleAdBannerViewDelegate() }
+    val delegate =
+        remember(adUnitId, bannerType, rootViewController) {
+            GoogleAdBannerViewDelegate()
+        }
     val adSize =
         when (bannerType) {
             is GoogleAdBannerType.InlineAdaptive -> {

--- a/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreview.kt
+++ b/feature/home/src/androidMain/kotlin/com/whatever/caramel/feature/home/HomeScreenPreview.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
 import com.whatever.caramel.core.ui.admob.GoogleAdBannerType
 import com.whatever.caramel.core.ui.admob.GoogleAdUnitIds
-import com.whatever.caramel.core.ui.admob.LocalHomeGoogleAdBanner
 import com.whatever.caramel.core.ui.admob.rememberGoogleAdBannerState
 import com.whatever.caramel.feature.home.mvi.HomeState
 

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeAdBanner.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeAdBanner.kt
@@ -1,0 +1,9 @@
+package com.whatever.caramel.feature.home
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.whatever.caramel.core.ui.admob.GoogleAdBannerState
+
+val LocalHomeGoogleAdBanner =
+    staticCompositionLocalOf<GoogleAdBannerState> {
+        error("No HomeGoogleAdBanner provided")
+    }

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/HomeScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -27,9 +26,8 @@ import com.whatever.caramel.core.designsystem.components.CaramelTopBar
 import com.whatever.caramel.core.designsystem.components.DefaultCaramelDialogLayout
 import com.whatever.caramel.core.designsystem.foundations.Resources
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
-import com.whatever.caramel.core.ui.admob.CaramelGoogleAdBanner
-import com.whatever.caramel.core.ui.admob.LocalHomeGoogleAdBanner
 import com.whatever.caramel.feature.home.components.ShareMessageBottomSheet
+import com.whatever.caramel.feature.home.components.googleAdBanner
 import com.whatever.caramel.feature.home.components.header.disconnectedCard
 import com.whatever.caramel.feature.home.components.header.header
 import com.whatever.caramel.feature.home.components.quiz.quiz
@@ -172,14 +170,7 @@ internal fun HomeScreen(
                     onClickEmptyTodo = { onIntent(HomeIntent.CreateTodoContent) },
                 )
 
-                item {
-                    CaramelGoogleAdBanner(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth(),
-                        bannerState = bannerState,
-                    )
-                }
+                googleAdBanner(bannerState = bannerState)
             }
         }
     }

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/GoogleAdBanner.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/GoogleAdBanner.kt
@@ -6,9 +6,7 @@ import androidx.compose.ui.Modifier
 import com.whatever.caramel.core.ui.admob.CaramelGoogleAdBanner
 import com.whatever.caramel.core.ui.admob.GoogleAdBannerState
 
-internal fun LazyListScope.googleAdBanner(
-    bannerState: GoogleAdBannerState,
-) {
+internal fun LazyListScope.googleAdBanner(bannerState: GoogleAdBannerState) {
     item(
         key = "home_google_ad_banner",
         contentType = "google_ad_banner",

--- a/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/GoogleAdBanner.kt
+++ b/feature/home/src/commonMain/kotlin/com/whatever/caramel/feature/home/components/GoogleAdBanner.kt
@@ -1,0 +1,21 @@
+package com.whatever.caramel.feature.home.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.ui.Modifier
+import com.whatever.caramel.core.ui.admob.CaramelGoogleAdBanner
+import com.whatever.caramel.core.ui.admob.GoogleAdBannerState
+
+internal fun LazyListScope.googleAdBanner(
+    bannerState: GoogleAdBannerState,
+) {
+    item(
+        key = "home_google_ad_banner",
+        contentType = "google_ad_banner",
+    ) {
+        CaramelGoogleAdBanner(
+            modifier = Modifier.fillMaxWidth(),
+            bannerState = bannerState,
+        )
+    }
+}

--- a/feature/main/src/commonMain/kotlin/com/whatever/caramel/feature/main/MainRoute.kt
+++ b/feature/main/src/commonMain/kotlin/com/whatever/caramel/feature/main/MainRoute.kt
@@ -27,11 +27,11 @@ import com.whatever.caramel.core.domain.vo.content.ContentType
 import com.whatever.caramel.core.ui.admob.GoogleAdBannerType
 import com.whatever.caramel.core.ui.admob.GoogleAdBannerType.AnchoredAdaptive.Companion.SCREEN_FULL_WIDTH
 import com.whatever.caramel.core.ui.admob.GoogleAdUnitIds
-import com.whatever.caramel.core.ui.admob.LocalHomeGoogleAdBanner
 import com.whatever.caramel.core.ui.admob.rememberGoogleAdBannerState
 import com.whatever.caramel.core.ui.util.ObserveLifecycleEvent
 import com.whatever.caramel.feature.calendar.navigation.calendarContent
 import com.whatever.caramel.feature.calendar.navigation.navigateToCalendar
+import com.whatever.caramel.feature.home.LocalHomeGoogleAdBanner
 import com.whatever.caramel.feature.home.navigation.HomeRoute
 import com.whatever.caramel.feature.home.navigation.homeContent
 import com.whatever.caramel.feature.home.navigation.navigateToHome
@@ -53,7 +53,7 @@ internal fun MainRoute(
 ) {
     val hapticFeedback = LocalHapticFeedback.current
     val mainNavHostController = rememberNavController()
-    val mainGoogleAdBannerState =
+    val homeGoogleAdBannerState =
         rememberGoogleAdBannerState(
             adUnitId = GoogleAdUnitIds.HOME_BANNER,
             bannerType = GoogleAdBannerType.AnchoredAdaptive(width = SCREEN_FULL_WIDTH),
@@ -120,7 +120,7 @@ internal fun MainRoute(
         },
     ) { innerPadding ->
         CompositionLocalProvider(
-            LocalHomeGoogleAdBanner provides mainGoogleAdBannerState,
+            LocalHomeGoogleAdBanner provides homeGoogleAdBannerState,
         ) {
             NavHost(
                 modifier =


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업한 내용
- Android `AdView`를 탭 전환 이후에도 재사용할 수 있도록 배너 상태 생명주기를 `MainRoute` 기준으로 조정했습니다.
- `AndroidView`에서는 기존 `AdView`를 attach/detach만 수행하고, 최종 해제는 `rememberGoogleAdBannerState`에서 처리하도록 역할을 분리했습니다.
- 홈 광고 배너 Lazy item을 `components` 패키지로 분리하고 stable key/contentType을 유지했습니다.
- iOS `GADBannerView`의 delegate/rootViewController 정리와 remember key를 보강했습니다.
- Android lint의 `MissingPermission` 오류를 해결했습니다.

## PR 포인트
- Crash 원인은 동일한 Android `AdView`가 이미 parent를 가진 상태에서 새 `AndroidViewHolder`에 다시 붙으려던 문제였습니다.
- 같은 `GoogleAdBannerState`는 하나의 배너 슬롯에서만 사용하는 전제가 있습니다.
- 검증: `./gradlew lintDebug`, `./gradlew :core:ui:compileKotlinIosSimulatorArm64`