### PR TITLE
[Fix] 메모 탭 resume 시 로딩뷰 없이 무음 리프레시

### DIFF
--- a/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoViewModel.kt
+++ b/feature/memo/src/commonMain/kotlin/com/whatever/caramel/feature/memo/MemoViewModel.kt
@@ -23,6 +23,8 @@ class MemoViewModel(
     savedStateHandle: SavedStateHandle,
     crashlytics: CaramelCrashlytics,
 ) : BaseViewModel<MemoState, MemoSideEffect, MemoIntent>(savedStateHandle, crashlytics) {
+    private var isInitialized = false
+
     override fun createInitialState(savedStateHandle: SavedStateHandle): MemoState = MemoState()
 
     override suspend fun handleIntent(intent: MemoIntent) {
@@ -72,6 +74,13 @@ class MemoViewModel(
     }
 
     private suspend fun initialize() {
+        // 최초 진입에서만 로딩뷰(스켈레톤)를 노출하고, 이후 resume 에서는 로딩뷰 없이 무음 리프레시한다.
+        if (isInitialized) {
+            silentRefresh()
+            return
+        }
+        isInitialized = true
+
         reduce {
             copy(
                 isTagLoading = true,
@@ -84,6 +93,54 @@ class MemoViewModel(
 
         initMemoList()
         initTagList()
+    }
+
+    /**
+     * resume 시 호출되는 무음 리프레시.
+     * 로딩 상태(memoContent = Loading, isTagLoading = true)로 전환하지 않고,
+     * 데이터를 모두 받아온 뒤 한 번에 교체해 스켈레톤 깜빡임을 없앤다.
+     * 기존 [initialize] 와 동일하게 전체 탭 기준 첫 페이지로 갱신한다.
+     */
+    private suspend fun silentRefresh() {
+        val tagListJob =
+            launch {
+                val fetchedTags = getAllTagsUseCase()
+                val newTagList = (persistentListOf(Tag(id = 0L, label = "")) + fetchedTags).toImmutableList()
+
+                reduce {
+                    copy(
+                        isTagLoading = false,
+                        tagList = newTagList,
+                        selectedTag = newTagList[0],
+                    )
+                }
+            }
+
+        val memoListJob =
+            launch {
+                val memoWithCursor =
+                    getMemoListUseCase(
+                        size = 10,
+                        cursor = null,
+                        tagId = 0L,
+                    )
+
+                val memoContentState =
+                    if (memoWithCursor.memos.isEmpty()) {
+                        MemoContentState.Empty
+                    } else {
+                        MemoContentState.Content(memoList = memoWithCursor.memos.toImmutableList())
+                    }
+
+                reduce {
+                    copy(
+                        cursor = memoWithCursor.nextCursor,
+                        memoContent = memoContentState,
+                    )
+                }
+            }
+
+        joinAll(tagListJob, memoListJob)
     }
 
     private suspend fun refresh() {


### PR DESCRIPTION
## 작업 내용
메모 탭에서 다른 화면(일정 생성, 메모 생성 등)에 갔다가 돌아올 때마다 데이터 리프레시와 함께 로딩 스켈레톤이 잠깐 노출되던 문제를 수정합니다.

- 최초 진입에서만 로딩뷰(스켈레톤)를 노출
- 이후 `ON_RESUME` 에서는 로딩 상태로 전환하지 않고, 태그/메모를 받아온 뒤 한 번에 교체하는 무음 리프레시(`silentRefresh`)로 처리하여 깜빡임 제거
- `isInitialized` 플래그로 최초/재진입 구분

## 변경 파일
- `feature/memo/.../MemoViewModel.kt`

## 동작
- 최초: 기존과 동일하게 스켈레톤 노출
- resume: 로딩뷰 없이 전체 탭/첫 페이지 기준으로 자연스럽게 리프레시

## 검증
- `:feature:memo:compileDebugKotlinAndroid` ✅
- `spotlessCheck` ✅
- 런타임(에뮬레이터) 동작 검증은 미수행

## 참고
- base 브랜치: `feat/balance_game_improve` (해당 작업 위에 스택)