### PR TITLE
[Feat] 밸런스 게임 공유 카드 이미지 추출/저장/공유 기반 구축

### DIFF
--- a/app-ios/iosApp/Info.plist
+++ b/app-ios/iosApp/Info.plist
@@ -265,6 +265,8 @@
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>Camera Permission required</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>밸런스 게임 결과 이미지를 사진 앨범에 저장하기 위해 사용됩니다.</string>
 	<key>NSUserTrackingUsageDescription</key>
 	<string>이 앱은 맞춤형 광고 및 딥링크 추적을 위해 사용자의 활동 정보를 사용합니다.</string>
 	<key>UIApplicationSceneManifest</key>

--- a/feature/balancegame/build.gradle.kts
+++ b/feature/balancegame/build.gradle.kts
@@ -22,5 +22,9 @@ kotlin {
             implementation(libs.jetbrains.androidx.lifecycle.runtime.compose)
             implementation(libs.jetbrains.androidx.compose.navigation)
         }
+
+        androidMain.dependencies {
+            implementation(libs.androidx.core.ktx)
+        }
     }
 }

--- a/feature/balancegame/src/androidMain/AndroidManifest.xml
+++ b/feature/balancegame/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+	xmlns:android="http://schemas.android.com/apk/res/android">
+
+	<uses-permission
+		android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+		android:maxSdkVersion="28" />
+
+	<application>
+		<provider android:name="androidx.core.content.FileProvider"
+			android:authorities="${applicationId}.fileprovider"
+			android:exported="false" android:grantUriPermissions="true">
+			<meta-data
+				android:name="android.support.FILE_PROVIDER_PATHS"
+				android:resource="@xml/file_paths" />
+		</provider>
+	</application>
+
+</manifest>

--- a/feature/balancegame/src/androidMain/kotlin/com/whatever/caramel/feature/balancegame/di/Module.android.kt
+++ b/feature/balancegame/src/androidMain/kotlin/com/whatever/caramel/feature/balancegame/di/Module.android.kt
@@ -1,0 +1,11 @@
+package com.whatever.caramel.feature.balancegame.di
+
+import com.whatever.caramel.feature.balancegame.share.image.AndroidImageShareManager
+import com.whatever.caramel.feature.balancegame.share.image.ImageShareManager
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val imageShareModule: Module =
+    module {
+        single<ImageShareManager> { AndroidImageShareManager(context = get()) }
+    }

--- a/feature/balancegame/src/androidMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/AndroidImageShareManager.kt
+++ b/feature/balancegame/src/androidMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/AndroidImageShareManager.kt
@@ -1,0 +1,121 @@
+package com.whatever.caramel.feature.balancegame.share.image
+
+import android.content.ContentValues
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.media.MediaScannerConnection
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+
+class AndroidImageShareManager(
+    private val context: Context,
+) : ImageShareManager {
+    override suspend fun saveToGallery(
+        image: ImageBitmap,
+        fileName: String,
+    ): Result<Unit> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val bitmap = image.toSoftwareBitmap()
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    saveViaMediaStore(bitmap, fileName)
+                } else {
+                    saveLegacy(bitmap, fileName)
+                }
+            }
+        }
+
+    override suspend fun shareImage(
+        image: ImageBitmap,
+        fileName: String,
+    ): Result<Unit> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val file = writePngToCache(image.toSoftwareBitmap(), fileName)
+                val uri =
+                    FileProvider.getUriForFile(
+                        context,
+                        "${context.packageName}.fileprovider",
+                        file,
+                    )
+                val shareIntent =
+                    Intent(Intent.ACTION_SEND).apply {
+                        type = MIME_PNG
+                        putExtra(Intent.EXTRA_STREAM, uri)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    }
+                context.startActivity(
+                    Intent.createChooser(shareIntent, "공유하기").apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    },
+                )
+            }
+        }
+
+    private fun saveViaMediaStore(
+        bitmap: Bitmap,
+        fileName: String,
+    ) {
+        val resolver = context.contentResolver
+        val values =
+            ContentValues().apply {
+                put(MediaStore.Images.Media.DISPLAY_NAME, "$fileName.png")
+                put(MediaStore.Images.Media.MIME_TYPE, MIME_PNG)
+                put(MediaStore.Images.Media.RELATIVE_PATH, "${Environment.DIRECTORY_PICTURES}/Caramel")
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            }
+        val uri =
+            resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+                ?: error("MediaStore insert returned null")
+        resolver.openOutputStream(uri)?.use { out ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        } ?: error("openOutputStream returned null")
+        values.clear()
+        values.put(MediaStore.Images.Media.IS_PENDING, 0)
+        resolver.update(uri, values, null, null)
+    }
+
+    private fun saveLegacy(
+        bitmap: Bitmap,
+        fileName: String,
+    ) {
+        @Suppress("DEPRECATION")
+        val picturesDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+        val dir = File(picturesDir, "Caramel").apply { if (!exists()) mkdirs() }
+        val file = File(dir, "$fileName.png")
+        FileOutputStream(file).use { out -> bitmap.compress(Bitmap.CompressFormat.PNG, 100, out) }
+        MediaScannerConnection.scanFile(context, arrayOf(file.absolutePath), arrayOf(MIME_PNG), null)
+    }
+
+    private fun writePngToCache(
+        bitmap: Bitmap,
+        fileName: String,
+    ): File {
+        val dir = File(context.cacheDir, "shared_images").apply { if (!exists()) mkdirs() }
+        val file = File(dir, "$fileName.png")
+        FileOutputStream(file).use { out -> bitmap.compress(Bitmap.CompressFormat.PNG, 100, out) }
+        return file
+    }
+
+    private fun ImageBitmap.toSoftwareBitmap(): Bitmap {
+        val androidBitmap = asAndroidBitmap()
+        return if (androidBitmap.config == Bitmap.Config.HARDWARE) {
+            androidBitmap.copy(Bitmap.Config.ARGB_8888, false)
+        } else {
+            androidBitmap
+        }
+    }
+
+    companion object {
+        private const val MIME_PNG = "image/png"
+    }
+}

--- a/feature/balancegame/src/androidMain/res/xml/file_paths.xml
+++ b/feature/balancegame/src/androidMain/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+	<cache-path
+		name="shared_images"
+		path="shared_images/" />
+</paths>

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/di/Module.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/di/Module.kt
@@ -2,11 +2,15 @@ package com.whatever.caramel.feature.balancegame.di
 
 import com.whatever.caramel.feature.balancegame.history.BalanceGameHistoryViewModel
 import com.whatever.caramel.feature.balancegame.share.BalanceGameShareViewModel
+import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
+expect val imageShareModule: Module
+
 val balanceGameFeatureModule =
     module {
+        includes(imageShareModule)
         viewModelOf(::BalanceGameHistoryViewModel)
         viewModelOf(::BalanceGameShareViewModel)
     }

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareRoute.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareRoute.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.whatever.caramel.core.designsystem.components.LocalSnackbarHostState
+import com.whatever.caramel.core.designsystem.components.showSnackbarMessage
 import com.whatever.caramel.feature.balancegame.share.mvi.BalanceGameShareSideEffect
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -13,11 +15,18 @@ internal fun BalanceGameShareRoute(
     navigateToBack: () -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHostState = LocalSnackbarHostState.current
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is BalanceGameShareSideEffect.NavigateToBack -> navigateToBack()
+                is BalanceGameShareSideEffect.ShowSnackBar ->
+                    showSnackbarMessage(
+                        snackbarHostState = snackbarHostState,
+                        coroutineScope = this,
+                        message = sideEffect.message,
+                    )
             }
         }
     }

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareScreen.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareScreen.kt
@@ -2,20 +2,35 @@ package com.whatever.caramel.feature.balancegame.share
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import caramel.feature.balancegame.generated.resources.Res
 import caramel.feature.balancegame.generated.resources.balance_game_share_title
+import com.whatever.caramel.core.designsystem.components.CaramelButton
+import com.whatever.caramel.core.designsystem.components.CaramelButtonSize
+import com.whatever.caramel.core.designsystem.components.CaramelButtonType
 import com.whatever.caramel.core.designsystem.components.CaramelTopBar
 import com.whatever.caramel.core.designsystem.foundations.Resources
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+import com.whatever.caramel.feature.balancegame.share.capture.capturable
+import com.whatever.caramel.feature.balancegame.share.capture.rememberCaptureController
+import com.whatever.caramel.feature.balancegame.share.component.MockShareCard
 import com.whatever.caramel.feature.balancegame.share.mvi.BalanceGameShareIntent
 import com.whatever.caramel.feature.balancegame.share.mvi.BalanceGameShareState
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -24,6 +39,9 @@ internal fun BalanceGameShareScreen(
     state: BalanceGameShareState,
     onIntent: (BalanceGameShareIntent) -> Unit,
 ) {
+    val captureController = rememberCaptureController()
+    val coroutineScope = rememberCoroutineScope()
+
     Column(
         modifier =
             Modifier
@@ -53,5 +71,56 @@ internal fun BalanceGameShareScreen(
                 )
             },
         )
+
+        Box(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(CaramelTheme.spacing.xl),
+            contentAlignment = Alignment.Center,
+        ) {
+            MockShareCard(modifier = Modifier.capturable(captureController))
+        }
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .navigationBarsPadding()
+                    .padding(
+                        horizontal = CaramelTheme.spacing.xl,
+                        vertical = CaramelTheme.spacing.l,
+                    ),
+            horizontalArrangement = Arrangement.spacedBy(CaramelTheme.spacing.s),
+        ) {
+            val buttonType =
+                if (state.exportInProgress) CaramelButtonType.Disabled else CaramelButtonType.Enabled2
+            CaramelButton(
+                modifier = Modifier.weight(1f),
+                buttonType = buttonType,
+                buttonSize = CaramelButtonSize.Large,
+                text = "저장하기",
+                onClick = {
+                    coroutineScope.launch {
+                        val image = captureController.capture()
+                        onIntent(BalanceGameShareIntent.ClickSaveImage(image))
+                    }
+                },
+            )
+            CaramelButton(
+                modifier = Modifier.weight(1f),
+                buttonType =
+                    if (state.exportInProgress) CaramelButtonType.Disabled else CaramelButtonType.Enabled1,
+                buttonSize = CaramelButtonSize.Large,
+                text = "공유하기",
+                onClick = {
+                    coroutineScope.launch {
+                        val image = captureController.capture()
+                        onIntent(BalanceGameShareIntent.ClickShareImage(image))
+                    }
+                },
+            )
+        }
     }
 }

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareViewModel.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareViewModel.kt
@@ -1,8 +1,10 @@
 package com.whatever.caramel.feature.balancegame.share
 
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.lifecycle.SavedStateHandle
 import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.viewmodel.BaseViewModel
+import com.whatever.caramel.feature.balancegame.share.image.ImageShareManager
 import com.whatever.caramel.feature.balancegame.share.mvi.BalanceGameShareIntent
 import com.whatever.caramel.feature.balancegame.share.mvi.BalanceGameShareSideEffect
 import com.whatever.caramel.feature.balancegame.share.mvi.BalanceGameShareState
@@ -10,12 +12,42 @@ import com.whatever.caramel.feature.balancegame.share.mvi.BalanceGameShareState
 class BalanceGameShareViewModel(
     savedStateHandle: SavedStateHandle,
     crashlytics: CaramelCrashlytics,
+    private val imageShareManager: ImageShareManager,
 ) : BaseViewModel<BalanceGameShareState, BalanceGameShareSideEffect, BalanceGameShareIntent>(savedStateHandle, crashlytics) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): BalanceGameShareState = BalanceGameShareState()
 
     override suspend fun handleIntent(intent: BalanceGameShareIntent) {
         when (intent) {
             is BalanceGameShareIntent.ClickBackButton -> postSideEffect(BalanceGameShareSideEffect.NavigateToBack)
+            is BalanceGameShareIntent.ClickSaveImage -> saveImage(intent.image)
+            is BalanceGameShareIntent.ClickShareImage -> shareImage(intent.image)
         }
+    }
+
+    private fun saveImage(image: ImageBitmap) {
+        if (currentState.exportInProgress) return
+        launch {
+            reduce { copy(exportInProgress = true) }
+            val result = imageShareManager.saveToGallery(image = image, fileName = IMAGE_FILE_NAME)
+            reduce { copy(exportInProgress = false) }
+            val message = if (result.isSuccess) "이미지를 저장했어요." else "이미지 저장에 실패했어요."
+            postSideEffect(BalanceGameShareSideEffect.ShowSnackBar(message))
+        }
+    }
+
+    private fun shareImage(image: ImageBitmap) {
+        if (currentState.exportInProgress) return
+        launch {
+            reduce { copy(exportInProgress = true) }
+            val result = imageShareManager.shareImage(image = image, fileName = IMAGE_FILE_NAME)
+            reduce { copy(exportInProgress = false) }
+            if (result.isFailure) {
+                postSideEffect(BalanceGameShareSideEffect.ShowSnackBar("이미지 공유에 실패했어요."))
+            }
+        }
+    }
+
+    companion object {
+        private const val IMAGE_FILE_NAME = "caramel_balance_game"
     }
 }

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/capture/CaptureController.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/capture/CaptureController.kt
@@ -1,0 +1,31 @@
+package com.whatever.caramel.feature.balancegame.share.capture
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+
+class CaptureController(
+    val graphicsLayer: GraphicsLayer,
+) {
+    suspend fun capture(): ImageBitmap = graphicsLayer.toImageBitmap()
+}
+
+@Composable
+fun rememberCaptureController(): CaptureController {
+    val graphicsLayer = rememberGraphicsLayer()
+    return remember(graphicsLayer) { CaptureController(graphicsLayer) }
+}
+
+fun Modifier.capturable(controller: CaptureController): Modifier =
+    drawWithContent {
+        val layer = controller.graphicsLayer
+        layer.record {
+            this@drawWithContent.drawContent()
+        }
+        drawLayer(layer)
+    }

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/component/MockShareCard.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/component/MockShareCard.kt
@@ -1,0 +1,73 @@
+package com.whatever.caramel.feature.balancegame.share.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.whatever.caramel.core.designsystem.themes.CaramelTheme
+
+@Composable
+internal fun MockShareCard(modifier: Modifier = Modifier) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(20.dp))
+                .background(color = CaramelTheme.color.fill.brand)
+                .padding(horizontal = CaramelTheme.spacing.xl, vertical = CaramelTheme.spacing.xxl),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(CaramelTheme.spacing.l),
+    ) {
+        Text(
+            text = "오늘의 밸런스 게임",
+            style = CaramelTheme.typography.label1.bold,
+            color = CaramelTheme.color.text.inverse,
+        )
+        Text(
+            text = "평생 한 가지 맛만\n먹어야 한다면?",
+            style = CaramelTheme.typography.heading2,
+            color = CaramelTheme.color.text.inverse,
+            textAlign = TextAlign.Center,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(CaramelTheme.spacing.s),
+        ) {
+            MockChoiceChip(modifier = Modifier.weight(1f), label = "🍫 단짠단짠")
+            MockChoiceChip(modifier = Modifier.weight(1f), label = "🌶️ 맵단맵단")
+        }
+        Text(
+            text = "우리 커플의 선택은?",
+            style = CaramelTheme.typography.body3.regular,
+            color = CaramelTheme.color.text.inverse,
+        )
+    }
+}
+
+@Composable
+private fun MockChoiceChip(
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(12.dp))
+                .background(color = CaramelTheme.color.fill.inverse)
+                .padding(vertical = CaramelTheme.spacing.m),
+        text = label,
+        style = CaramelTheme.typography.body2.bold,
+        color = CaramelTheme.color.text.brand,
+        textAlign = TextAlign.Center,
+    )
+}

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/ImageShareManager.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/ImageShareManager.kt
@@ -1,0 +1,15 @@
+package com.whatever.caramel.feature.balancegame.share.image
+
+import androidx.compose.ui.graphics.ImageBitmap
+
+interface ImageShareManager {
+    suspend fun saveToGallery(
+        image: ImageBitmap,
+        fileName: String,
+    ): Result<Unit>
+
+    suspend fun shareImage(
+        image: ImageBitmap,
+        fileName: String,
+    ): Result<Unit>
+}

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareIntent.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareIntent.kt
@@ -1,7 +1,16 @@
 package com.whatever.caramel.feature.balancegame.share.mvi
 
+import androidx.compose.ui.graphics.ImageBitmap
 import com.whatever.caramel.core.viewmodel.UiIntent
 
 sealed interface BalanceGameShareIntent : UiIntent {
     data object ClickBackButton : BalanceGameShareIntent
+
+    data class ClickSaveImage(
+        val image: ImageBitmap,
+    ) : BalanceGameShareIntent
+
+    data class ClickShareImage(
+        val image: ImageBitmap,
+    ) : BalanceGameShareIntent
 }

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareSideEffect.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareSideEffect.kt
@@ -4,4 +4,8 @@ import com.whatever.caramel.core.viewmodel.UiSideEffect
 
 sealed interface BalanceGameShareSideEffect : UiSideEffect {
     data object NavigateToBack : BalanceGameShareSideEffect
+
+    data class ShowSnackBar(
+        val message: String,
+    ) : BalanceGameShareSideEffect
 }

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareState.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareState.kt
@@ -4,4 +4,5 @@ import com.whatever.caramel.core.viewmodel.UiState
 
 data class BalanceGameShareState(
     val isLoading: Boolean = false,
+    val exportInProgress: Boolean = false,
 ) : UiState

--- a/feature/balancegame/src/iosMain/kotlin/com/whatever/caramel/feature/balancegame/di/Module.ios.kt
+++ b/feature/balancegame/src/iosMain/kotlin/com/whatever/caramel/feature/balancegame/di/Module.ios.kt
@@ -1,0 +1,11 @@
+package com.whatever.caramel.feature.balancegame.di
+
+import com.whatever.caramel.feature.balancegame.share.image.ImageShareManager
+import com.whatever.caramel.feature.balancegame.share.image.IosImageShareManager
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val imageShareModule: Module =
+    module {
+        single<ImageShareManager> { IosImageShareManager() }
+    }

--- a/feature/balancegame/src/iosMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/IosImageShareManager.kt
+++ b/feature/balancegame/src/iosMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/IosImageShareManager.kt
@@ -1,0 +1,62 @@
+package com.whatever.caramel.feature.balancegame.share.image
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asSkiaBitmap
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+import platform.Foundation.NSData
+import platform.Foundation.create
+import platform.UIKit.UIActivityViewController
+import platform.UIKit.UIApplication
+import platform.UIKit.UIImage
+import platform.UIKit.UIImageWriteToSavedPhotosAlbum
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+class IosImageShareManager : ImageShareManager {
+    override suspend fun saveToGallery(
+        image: ImageBitmap,
+        fileName: String,
+    ): Result<Unit> =
+        withContext(Dispatchers.Main) {
+            runCatching {
+                UIImageWriteToSavedPhotosAlbum(image.toUIImage(), null, null, null)
+            }
+        }
+
+    override suspend fun shareImage(
+        image: ImageBitmap,
+        fileName: String,
+    ): Result<Unit> =
+        withContext(Dispatchers.Main) {
+            runCatching {
+                val controller =
+                    UIActivityViewController(
+                        activityItems = listOf(image.toUIImage()),
+                        applicationActivities = null,
+                    )
+                val rootViewController =
+                    UIApplication.sharedApplication.keyWindow?.rootViewController
+                        ?: error("rootViewController is null")
+                rootViewController.presentViewController(controller, animated = true, completion = null)
+            }
+        }
+
+    private fun ImageBitmap.toUIImage(): UIImage {
+        val skiaImage = Image.makeFromBitmap(asSkiaBitmap())
+        val pngData =
+            skiaImage.encodeToData(EncodedImageFormat.PNG)
+                ?: error("PNG encoding failed")
+        val bytes = pngData.bytes
+        val nsData =
+            bytes.usePinned { pinned ->
+                NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
+            }
+        return UIImage.imageWithData(nsData) ?: error("UIImage creation failed")
+    }
+}


### PR DESCRIPTION
## 작업 내용

밸런스 게임 결과를 이미지로 공유하기 위한 기반 작업입니다. 실제 공유 카드 디자인과 API 연동은 이후 작업이고, 이번엔 나중에 카드만 갈아끼우면 바로 저장/공유로 이어지도록 추출 흐름을 먼저 잡아뒀습니다.

- 공유 카드처럼 특정 영역만 이미지로 캡처하는 구조 추가 (화면 전체가 아니라 카드 영역만)
- 캡처한 이미지를 갤러리에 저장하거나 시스템 공유 시트로 공유하는 기능을 플랫폼별로 구현
- 저장/공유 진행·성공·실패 상태를 화면에서 확인할 수 있게 처리 (기존 스낵바 활용)
- 동작 확인용 임시 Mock 카드 화면 추가. 추후 실제 공유 카드로 교체
- iOS 사진 저장 권한 설명 문구 추가

저장하기/공유하기 버튼은 분리했고, 실제 공유 카드가 나오면 Mock 카드 자리만 바꾸면 됩니다.

## 검증

Android는 에뮬레이터에서 직접 확인했습니다. 홈 → 결과 공유하기로 들어가서 저장하면 갤러리에 들어가고, 공유하면 공유 시트가 뜹니다. 저장된 이미지도 상단바/버튼 없이 카드 영역만 잘 잘립니다.

iOS는 빌드와 구조까지만 확인했고 실기 동작은 아직입니다. dev 서버가 Zscaler 사내 SSL 검사 프록시 인증서를 쓰는데 시뮬레이터에는 그 루트 인증서가 없어서 로그인 단계에서 막혔습니다. 사내망 실기기나 루트 인증서가 깔린 환경에서 확인이 필요해, iOS 검증은 따로 요청드리려 합니다.

## 참고

- 밸런스게임 진입점이 아직 develop에 머지되지 않아 base는 feat/balance_game_improve로 잡았습니다.