### PR TITLE
[Build] iOS Qa.xcconfig 번들 포함 제거

### DIFF
--- a/app-ios/iosApp.xcodeproj/project.pbxproj
+++ b/app-ios/iosApp.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		E962CE8E2EE05011008E1284 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E97442F22DF2DB2B00B9CDEE /* GoogleService-Info.plist */; };
 		E972E3D02ED82BB40084F00C /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = E972E3CF2ED82BB40084F00C /* GoogleMobileAds */; };
 		E97442F12DF2DAC400B9CDEE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E97442F02DF2DAC400B9CDEE /* Assets.xcassets */; };
-		E98165282EDF102D0015367C /* Qa.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = E98165272EDF102D0015367C /* Qa.xcconfig */; };
 		E987BEB22DEB080E00CE545C /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = E987BEB12DEB080E00CE545C /* FirebaseMessaging */; };
 		E987BEBD2DEB63D200CE545C /* MessagingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E987BEBC2DEB63D200CE545C /* MessagingDelegate.swift */; };
 		E987BEBF2DEB640800CE545C /* NotificationCenterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E987BEBE2DEB640800CE545C /* NotificationCenterDelegate.swift */; };
@@ -230,7 +229,6 @@
 			files = (
 				E962CE8D2EE05011008E1284 /* GoogleService-Info-Qa.plist in Resources */,
 				E962CE8E2EE05011008E1284 /* GoogleService-Info.plist in Resources */,
-				E98165282EDF102D0015367C /* Qa.xcconfig in Resources */,
 				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
 				E97442F12DF2DAC400B9CDEE /* Assets.xcassets in Resources */,
 			);


### PR DESCRIPTION
## 관련 이슈
- Closes #413

## 작업한 내용
- `Qa.xcconfig`의 `PBXBuildFile` 리소스 등록을 제거했습니다.
- iOS 타깃의 `Copy Bundle Resources`에서 `Qa.xcconfig`를 제거했습니다.
- QA Build Configuration의 파일 참조와 `baseConfigurationReference`는 유지했습니다.

## PR 포인트
- QA 빌드 설정은 기존처럼 `Qa.xcconfig`에서 읽습니다.
- 앱 번들에 `.xcconfig` 원본이 포함되는 경로만 제거한 변경입니다.
- Firebase plist 선택 및 Crashlytics 빌드 페이즈는 변경하지 않았습니다.

## 검증
- `plutil -lint app-ios/iosApp.xcodeproj/project.pbxproj`
- `Qa.xcconfig in Resources` 참조가 제거됐는지 확인
- `xcodebuild -showBuildSettings`로 `Qa` 구성, QA 번들 ID 및 xcconfig 설정 해석 확인