### PR TITLE
[Build] iOS Firebase plist 선택 스크립트 실행 순서 조정

### DIFF
--- a/app-ios/iosApp.xcodeproj/project.pbxproj
+++ b/app-ios/iosApp.xcodeproj/project.pbxproj
@@ -171,8 +171,8 @@
 				7555FF78242A565900829871 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
 				7555FFB4242A642300829871 /* Embed Frameworks */,
-				BABA8A5E2D7330F300E0C23B /* ShellScript */,
 				E962CE8C2EE04C52008E1284 /* ShellScript */,
+				BABA8A5E2D7330F300E0C23B /* ShellScript */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
## 관련 이슈

- close #414

## 작업한 내용

- iOS 앱의 Build Phases에서 Firebase plist 선택 스크립트를 Crashlytics dSYM 업로드 스크립트보다 먼저 실행하도록 순서를 조정했습니다.
- QA 빌드 시 `GoogleService-Info-Qa.plist`가 `GoogleService-Info.plist`로 준비된 후 Crashlytics 업로드가 실행되도록 했습니다.

## PR 포인트

- 스크립트 로직은 변경하지 않고 `project.pbxproj`의 Build Phase 순서만 변경했습니다.
- `xcodebuild -list -project app-ios/iosApp.xcodeproj`로 프로젝트와 `Qa` 구성을 확인했습니다.
- phase ID와 스크립트 내용을 검사해 Firebase 설정 선택이 Crashlytics 업로드보다 먼저 실행되는 것을 확인했습니다.
- `git diff --check`를 통과했습니다.