### PR TITLE
[Fix] Android 9 이미지 저장 권한 처리

### DIFF
--- a/feature/balancegame/build.gradle.kts
+++ b/feature/balancegame/build.gradle.kts
@@ -25,6 +25,8 @@ kotlin {
             implementation(libs.jetbrains.androidx.compose.navigation)
             implementation(libs.kotlinx.date.time)
             implementation(libs.kotlinx.collections.immutable)
+            implementation(libs.moko.permission.compose)
+            implementation(libs.moko.permission.storage)
         }
 
         androidMain.dependencies {

--- a/feature/balancegame/src/androidMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/GallerySavePermissionRequester.android.kt
+++ b/feature/balancegame/src/androidMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/GallerySavePermissionRequester.android.kt
@@ -1,0 +1,5 @@
+package com.whatever.caramel.feature.balancegame.share.image
+
+import android.os.Build
+
+internal actual fun requiresLegacyGalleryWritePermission(): Boolean = Build.VERSION.SDK_INT <= Build.VERSION_CODES.P

--- a/feature/balancegame/src/commonMain/composeResources/values/strings.xml
+++ b/feature/balancegame/src/commonMain/composeResources/values/strings.xml
@@ -10,4 +10,8 @@
 	<string name="balance_game_share_description">우리의 밸런스 게임 결과를\n이미지로 저장하고 공유해보세요!</string>
 	<string name="balance_game_share_save_button">이미지 저장하기</string>
 	<string name="balance_game_share_share_button">공유하기</string>
+	<string name="balance_game_share_save_success">이미지를 저장했어요.</string>
+	<string name="balance_game_share_save_failure">이미지 저장에 실패했어요.</string>
+	<string name="balance_game_share_share_failure">이미지 공유에 실패했어요.</string>
+	<string name="balance_game_share_gallery_permission_required">이미지를 저장하려면 사진 접근 권한이 필요해요.</string>
 </resources>

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareRoute.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareRoute.kt
@@ -3,10 +3,22 @@ package com.whatever.caramel.feature.balancegame.share
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.whatever.caramel.core.designsystem.components.LocalSnackbarHostState
 import com.whatever.caramel.core.designsystem.components.showSnackbarMessage
+import com.whatever.caramel.feature.balancegame.share.image.requiresLegacyGalleryWritePermission
+import com.whatever.caramel.feature.balancegame.share.mvi.BalanceGameShareIntent
 import com.whatever.caramel.feature.balancegame.share.mvi.BalanceGameShareSideEffect
+import dev.icerock.moko.permissions.DeniedAlwaysException
+import dev.icerock.moko.permissions.DeniedException
+import dev.icerock.moko.permissions.Permission
+import dev.icerock.moko.permissions.RequestCanceledException
+import dev.icerock.moko.permissions.compose.BindEffect
+import dev.icerock.moko.permissions.compose.rememberPermissionsControllerFactory
+import dev.icerock.moko.permissions.storage.WRITE_STORAGE
+import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -16,6 +28,11 @@ internal fun BalanceGameShareRoute(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = LocalSnackbarHostState.current
+    val coroutineScope = rememberCoroutineScope()
+    val permissionFactory = rememberPermissionsControllerFactory()
+    val permissionsController = remember(permissionFactory) { permissionFactory.createPermissionsController() }
+
+    BindEffect(permissionsController = permissionsController)
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->
@@ -33,6 +50,29 @@ internal fun BalanceGameShareRoute(
 
     BalanceGameShareScreen(
         state = state,
-        onIntent = { intent -> viewModel.intent(intent) },
+        onIntent = { intent ->
+            when (intent) {
+                is BalanceGameShareIntent.ClickSaveImage ->
+                    coroutineScope.launch {
+                        if (!requiresLegacyGalleryWritePermission()) {
+                            viewModel.intent(intent)
+                            return@launch
+                        }
+
+                        try {
+                            permissionsController.providePermission(Permission.WRITE_STORAGE)
+                            viewModel.intent(intent)
+                        } catch (_: DeniedAlwaysException) {
+                            viewModel.intent(BalanceGameShareIntent.SaveImagePermissionDenied)
+                        } catch (_: DeniedException) {
+                            viewModel.intent(BalanceGameShareIntent.SaveImagePermissionDenied)
+                        } catch (_: RequestCanceledException) {
+                            viewModel.intent(BalanceGameShareIntent.SaveImagePermissionDenied)
+                        }
+                    }
+
+                else -> viewModel.intent(intent)
+            }
+        },
     )
 }

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareRoute.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareRoute.kt
@@ -5,7 +5,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import caramel.feature.balancegame.generated.resources.Res
+import caramel.feature.balancegame.generated.resources.balance_game_share_gallery_permission_required
+import caramel.feature.balancegame.generated.resources.balance_game_share_save_failure
+import caramel.feature.balancegame.generated.resources.balance_game_share_save_success
+import caramel.feature.balancegame.generated.resources.balance_game_share_share_failure
 import com.whatever.caramel.core.designsystem.components.LocalSnackbarHostState
 import com.whatever.caramel.core.designsystem.components.showSnackbarMessage
 import com.whatever.caramel.feature.balancegame.share.image.requiresLegacyGalleryWritePermission
@@ -19,6 +25,7 @@ import dev.icerock.moko.permissions.compose.BindEffect
 import dev.icerock.moko.permissions.compose.rememberPermissionsControllerFactory
 import dev.icerock.moko.permissions.storage.WRITE_STORAGE
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -31,6 +38,14 @@ internal fun BalanceGameShareRoute(
     val coroutineScope = rememberCoroutineScope()
     val permissionFactory = rememberPermissionsControllerFactory()
     val permissionsController = remember(permissionFactory) { permissionFactory.createPermissionsController() }
+    val imageSaveSuccessMessage =
+        rememberUpdatedState(stringResource(Res.string.balance_game_share_save_success))
+    val imageSaveFailureMessage =
+        rememberUpdatedState(stringResource(Res.string.balance_game_share_save_failure))
+    val imageShareFailureMessage =
+        rememberUpdatedState(stringResource(Res.string.balance_game_share_share_failure))
+    val galleryPermissionRequiredMessage =
+        rememberUpdatedState(stringResource(Res.string.balance_game_share_gallery_permission_required))
 
     BindEffect(permissionsController = permissionsController)
 
@@ -38,12 +53,21 @@ internal fun BalanceGameShareRoute(
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is BalanceGameShareSideEffect.NavigateToBack -> navigateToBack()
-                is BalanceGameShareSideEffect.ShowSnackBar ->
+                is BalanceGameShareSideEffect.ShowSnackBar -> {
+                    val message =
+                        when (sideEffect) {
+                            is BalanceGameShareSideEffect.ShowSnackBar.ImageSaveSuccess -> imageSaveSuccessMessage.value
+                            is BalanceGameShareSideEffect.ShowSnackBar.ImageSaveFailure -> imageSaveFailureMessage.value
+                            is BalanceGameShareSideEffect.ShowSnackBar.ImageShareFailure -> imageShareFailureMessage.value
+                            is BalanceGameShareSideEffect.ShowSnackBar.GalleryPermissionRequired ->
+                                galleryPermissionRequiredMessage.value
+                        }
                     showSnackbarMessage(
                         snackbarHostState = snackbarHostState,
                         coroutineScope = this,
-                        message = sideEffect.message,
+                        message = message,
                     )
+                }
             }
         }
     }

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareViewModel.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareViewModel.kt
@@ -35,7 +35,7 @@ class BalanceGameShareViewModel(
             is BalanceGameShareIntent.ClickSaveImage -> saveImage(intent.image)
             is BalanceGameShareIntent.ClickShareImage -> shareImage(intent.image)
             is BalanceGameShareIntent.SaveImagePermissionDenied ->
-                postSideEffect(BalanceGameShareSideEffect.ShowSnackBar("이미지를 저장하려면 사진 접근 권한이 필요해요."))
+                postSideEffect(BalanceGameShareSideEffect.ShowSnackBar.GalleryPermissionRequired)
         }
     }
 
@@ -45,8 +45,13 @@ class BalanceGameShareViewModel(
             reduce { copy(exportInProgress = true) }
             val result = imageShareManager.saveToGallery(image = image, fileName = IMAGE_FILE_NAME)
             reduce { copy(exportInProgress = false) }
-            val message = if (result.isSuccess) "이미지를 저장했어요." else "이미지 저장에 실패했어요."
-            postSideEffect(BalanceGameShareSideEffect.ShowSnackBar(message))
+            val sideEffect =
+                if (result.isSuccess) {
+                    BalanceGameShareSideEffect.ShowSnackBar.ImageSaveSuccess
+                } else {
+                    BalanceGameShareSideEffect.ShowSnackBar.ImageSaveFailure
+                }
+            postSideEffect(sideEffect)
         }
     }
 
@@ -57,7 +62,7 @@ class BalanceGameShareViewModel(
             val result = imageShareManager.shareImage(image = image, fileName = IMAGE_FILE_NAME)
             reduce { copy(exportInProgress = false) }
             if (result.isFailure) {
-                postSideEffect(BalanceGameShareSideEffect.ShowSnackBar("이미지 공유에 실패했어요."))
+                postSideEffect(BalanceGameShareSideEffect.ShowSnackBar.ImageShareFailure)
             }
         }
     }

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareViewModel.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareViewModel.kt
@@ -34,6 +34,8 @@ class BalanceGameShareViewModel(
             is BalanceGameShareIntent.ClickBackButton -> postSideEffect(BalanceGameShareSideEffect.NavigateToBack)
             is BalanceGameShareIntent.ClickSaveImage -> saveImage(intent.image)
             is BalanceGameShareIntent.ClickShareImage -> shareImage(intent.image)
+            is BalanceGameShareIntent.SaveImagePermissionDenied ->
+                postSideEffect(BalanceGameShareSideEffect.ShowSnackBar("이미지를 저장하려면 사진 접근 권한이 필요해요."))
         }
     }
 

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/GallerySavePermissionRequester.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/GallerySavePermissionRequester.kt
@@ -1,0 +1,3 @@
+package com.whatever.caramel.feature.balancegame.share.image
+
+internal expect fun requiresLegacyGalleryWritePermission(): Boolean

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareIntent.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareIntent.kt
@@ -13,4 +13,6 @@ sealed interface BalanceGameShareIntent : UiIntent {
     data class ClickShareImage(
         val image: ImageBitmap,
     ) : BalanceGameShareIntent
+
+    data object SaveImagePermissionDenied : BalanceGameShareIntent
 }

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareSideEffect.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareSideEffect.kt
@@ -5,7 +5,13 @@ import com.whatever.caramel.core.viewmodel.UiSideEffect
 sealed interface BalanceGameShareSideEffect : UiSideEffect {
     data object NavigateToBack : BalanceGameShareSideEffect
 
-    data class ShowSnackBar(
-        val message: String,
-    ) : BalanceGameShareSideEffect
+    sealed interface ShowSnackBar : BalanceGameShareSideEffect {
+        data object ImageSaveSuccess : ShowSnackBar
+
+        data object ImageSaveFailure : ShowSnackBar
+
+        data object ImageShareFailure : ShowSnackBar
+
+        data object GalleryPermissionRequired : ShowSnackBar
+    }
 }

--- a/feature/balancegame/src/iosMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/GallerySavePermissionRequester.ios.kt
+++ b/feature/balancegame/src/iosMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/GallerySavePermissionRequester.ios.kt
@@ -1,0 +1,3 @@
+package com.whatever.caramel.feature.balancegame.share.image
+
+internal actual fun requiresLegacyGalleryWritePermission(): Boolean = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -130,6 +130,7 @@ napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 # Permission
 moko-permission-compose = { group = "dev.icerock.moko", name = "permissions-compose", version.ref = "moko" }
 moko-permission-notifications = { group = "dev.icerock.moko", name = "permissions-notifications", version.ref = "moko" }
+moko-permission-storage = { group = "dev.icerock.moko", name = "permissions-storage", version.ref = "moko" }
 
 # Firebase
 firebase-bom-android = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase" }


### PR DESCRIPTION
## [관련 이슈]
- Closes #421

## [작업한 내용]
- Moko Permissions의 storage 모듈을 추가했습니다.
- Android 9(API 28)에서 이미지 저장 전 `WRITE_EXTERNAL_STORAGE` 권한을 요청하도록 수정했습니다.
- 권한 허용 후에만 이미지 저장을 실행하고, 거부·영구 거부·요청 취소 시 안내 스낵바를 노출합니다.
- 이미지 저장 및 공유 결과 문구를 모듈의 문자열 리소스로 이동했습니다.

## [PR 포인트]
- API 29 이상은 MediaStore 저장 경로를 사용하므로 legacy 저장 권한 요청을 생략합니다.
- iOS에서는 Android legacy 저장 권한 분기를 실행하지 않습니다.
- `:feature:balancegame:spotlessCheck`, Android/iOS 컴파일, `:android-app:assembleDebug`를 확인했습니다.