### PR TITLE
[Fix] iOS 이미지 저장 권한 및 완료 처리 개선

### DIFF
--- a/feature/balancegame/src/commonMain/composeResources/values/strings.xml
+++ b/feature/balancegame/src/commonMain/composeResources/values/strings.xml
@@ -14,4 +14,10 @@
 	<string name="balance_game_share_save_failure">이미지 저장에 실패했어요.</string>
 	<string name="balance_game_share_share_failure">이미지 공유에 실패했어요.</string>
 	<string name="balance_game_share_gallery_permission_required">이미지를 저장하려면 사진 접근 권한이 필요해요.</string>
+	<string name="balance_game_share_photo_permission_dialog_title">사진 저장 권한이 필요해요</string>
+	<string
+		name="balance_game_share_photo_permission_dialog_message">설정에서 사진 추가 권한을 허용한 뒤 다시 시도해주세요.</string>
+	<string
+		name="balance_game_share_photo_permission_dialog_settings">설정으로 이동</string>
+	<string name="balance_game_share_photo_permission_dialog_cancel">취소</string>
 </resources>

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareRoute.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareRoute.kt
@@ -53,6 +53,7 @@ internal fun BalanceGameShareRoute(
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is BalanceGameShareSideEffect.NavigateToBack -> navigateToBack()
+                is BalanceGameShareSideEffect.OpenPhotoPermissionSettings -> permissionsController.openAppSettings()
                 is BalanceGameShareSideEffect.ShowSnackBar -> {
                     val message =
                         when (sideEffect) {

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareScreen.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareScreen.kt
@@ -20,13 +20,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import caramel.feature.balancegame.generated.resources.Res
 import caramel.feature.balancegame.generated.resources.balance_game_share_description
+import caramel.feature.balancegame.generated.resources.balance_game_share_photo_permission_dialog_cancel
+import caramel.feature.balancegame.generated.resources.balance_game_share_photo_permission_dialog_message
+import caramel.feature.balancegame.generated.resources.balance_game_share_photo_permission_dialog_settings
+import caramel.feature.balancegame.generated.resources.balance_game_share_photo_permission_dialog_title
 import caramel.feature.balancegame.generated.resources.balance_game_share_save_button
 import caramel.feature.balancegame.generated.resources.balance_game_share_share_button
 import caramel.feature.balancegame.generated.resources.balance_game_share_title
 import com.whatever.caramel.core.designsystem.components.CaramelButton
 import com.whatever.caramel.core.designsystem.components.CaramelButtonSize
 import com.whatever.caramel.core.designsystem.components.CaramelButtonType
+import com.whatever.caramel.core.designsystem.components.CaramelDialog
 import com.whatever.caramel.core.designsystem.components.CaramelTopBar
+import com.whatever.caramel.core.designsystem.components.DefaultCaramelDialogLayout
 import com.whatever.caramel.core.designsystem.foundations.Resources
 import com.whatever.caramel.core.designsystem.themes.CaramelTheme
 import com.whatever.caramel.feature.balancegame.share.capture.capturable
@@ -45,6 +51,21 @@ internal fun BalanceGameShareScreen(
 ) {
     val captureController = rememberCaptureController()
     val coroutineScope = rememberCoroutineScope()
+
+    if (state.isShowPhotoPermissionDialog) {
+        CaramelDialog(
+            show = state.isShowPhotoPermissionDialog,
+            title = stringResource(resource = Res.string.balance_game_share_photo_permission_dialog_title),
+            message = stringResource(resource = Res.string.balance_game_share_photo_permission_dialog_message),
+            mainButtonText = stringResource(resource = Res.string.balance_game_share_photo_permission_dialog_settings),
+            subButtonText = stringResource(resource = Res.string.balance_game_share_photo_permission_dialog_cancel),
+            onDismissRequest = { onIntent(BalanceGameShareIntent.DismissPhotoPermissionDialog) },
+            onMainButtonClick = { onIntent(BalanceGameShareIntent.ClickPhotoPermissionSettingsButton) },
+            onSubButtonClick = { onIntent(BalanceGameShareIntent.DismissPhotoPermissionDialog) },
+        ) {
+            DefaultCaramelDialogLayout()
+        }
+    }
 
     Column(
         modifier =

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareViewModel.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/BalanceGameShareViewModel.kt
@@ -7,6 +7,7 @@ import com.whatever.caramel.core.crashlytics.CaramelCrashlytics
 import com.whatever.caramel.core.domain.vo.user.Gender
 import com.whatever.caramel.core.viewmodel.BaseViewModel
 import com.whatever.caramel.feature.balancegame.share.image.ImageShareManager
+import com.whatever.caramel.feature.balancegame.share.image.PhotoLibraryPermissionDeniedException
 import com.whatever.caramel.feature.balancegame.share.mvi.BalanceGameShareIntent
 import com.whatever.caramel.feature.balancegame.share.mvi.BalanceGameShareSideEffect
 import com.whatever.caramel.feature.balancegame.share.mvi.BalanceGameShareState
@@ -34,6 +35,8 @@ class BalanceGameShareViewModel(
             is BalanceGameShareIntent.ClickBackButton -> postSideEffect(BalanceGameShareSideEffect.NavigateToBack)
             is BalanceGameShareIntent.ClickSaveImage -> saveImage(intent.image)
             is BalanceGameShareIntent.ClickShareImage -> shareImage(intent.image)
+            is BalanceGameShareIntent.DismissPhotoPermissionDialog -> hidePhotoPermissionDialog()
+            is BalanceGameShareIntent.ClickPhotoPermissionSettingsButton -> openPhotoPermissionSettings()
             is BalanceGameShareIntent.SaveImagePermissionDenied ->
                 postSideEffect(BalanceGameShareSideEffect.ShowSnackBar.GalleryPermissionRequired)
         }
@@ -45,13 +48,19 @@ class BalanceGameShareViewModel(
             reduce { copy(exportInProgress = true) }
             val result = imageShareManager.saveToGallery(image = image, fileName = IMAGE_FILE_NAME)
             reduce { copy(exportInProgress = false) }
-            val sideEffect =
-                if (result.isSuccess) {
-                    BalanceGameShareSideEffect.ShowSnackBar.ImageSaveSuccess
-                } else {
-                    BalanceGameShareSideEffect.ShowSnackBar.ImageSaveFailure
+            when {
+                result.isSuccess -> {
+                    postSideEffect(BalanceGameShareSideEffect.ShowSnackBar.ImageSaveSuccess)
                 }
-            postSideEffect(sideEffect)
+
+                result.exceptionOrNull() is PhotoLibraryPermissionDeniedException -> {
+                    reduce { copy(isShowPhotoPermissionDialog = true) }
+                }
+
+                else -> {
+                    postSideEffect(BalanceGameShareSideEffect.ShowSnackBar.ImageSaveFailure)
+                }
+            }
         }
     }
 
@@ -65,6 +74,15 @@ class BalanceGameShareViewModel(
                 postSideEffect(BalanceGameShareSideEffect.ShowSnackBar.ImageShareFailure)
             }
         }
+    }
+
+    private fun hidePhotoPermissionDialog() {
+        reduce { copy(isShowPhotoPermissionDialog = false) }
+    }
+
+    private fun openPhotoPermissionSettings() {
+        reduce { copy(isShowPhotoPermissionDialog = false) }
+        postSideEffect(BalanceGameShareSideEffect.OpenPhotoPermissionSettings)
     }
 
     companion object {

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/ImageShareManager.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/ImageShareManager.kt
@@ -13,3 +13,5 @@ interface ImageShareManager {
         fileName: String,
     ): Result<Unit>
 }
+
+class PhotoLibraryPermissionDeniedException : Exception("Photo library add permission denied")

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareIntent.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareIntent.kt
@@ -15,4 +15,8 @@ sealed interface BalanceGameShareIntent : UiIntent {
     ) : BalanceGameShareIntent
 
     data object SaveImagePermissionDenied : BalanceGameShareIntent
+
+    data object DismissPhotoPermissionDialog : BalanceGameShareIntent
+
+    data object ClickPhotoPermissionSettingsButton : BalanceGameShareIntent
 }

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareSideEffect.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareSideEffect.kt
@@ -5,6 +5,8 @@ import com.whatever.caramel.core.viewmodel.UiSideEffect
 sealed interface BalanceGameShareSideEffect : UiSideEffect {
     data object NavigateToBack : BalanceGameShareSideEffect
 
+    data object OpenPhotoPermissionSettings : BalanceGameShareSideEffect
+
     sealed interface ShowSnackBar : BalanceGameShareSideEffect {
         data object ImageSaveSuccess : ShowSnackBar
 

--- a/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareState.kt
+++ b/feature/balancegame/src/commonMain/kotlin/com/whatever/caramel/feature/balancegame/share/mvi/BalanceGameShareState.kt
@@ -6,6 +6,7 @@ import com.whatever.caramel.core.viewmodel.UiState
 data class BalanceGameShareState(
     val isLoading: Boolean = false,
     val exportInProgress: Boolean = false,
+    val isShowPhotoPermissionDialog: Boolean = false,
     val question: String = "",
     val myChoice: String = "",
     val partnerChoice: String = "",

--- a/feature/balancegame/src/iosMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/IosImageShareManager.kt
+++ b/feature/balancegame/src/iosMain/kotlin/com/whatever/caramel/feature/balancegame/share/image/IosImageShareManager.kt
@@ -7,15 +7,23 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import org.jetbrains.skia.EncodedImageFormat
 import org.jetbrains.skia.Image
 import platform.Foundation.NSData
 import platform.Foundation.create
+import platform.Photos.PHAccessLevelAddOnly
+import platform.Photos.PHAssetChangeRequest
+import platform.Photos.PHAuthorizationStatusAuthorized
+import platform.Photos.PHAuthorizationStatusLimited
+import platform.Photos.PHAuthorizationStatusNotDetermined
+import platform.Photos.PHPhotoLibrary
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
 import platform.UIKit.UIImage
-import platform.UIKit.UIImageWriteToSavedPhotosAlbum
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 class IosImageShareManager : ImageShareManager {
@@ -25,7 +33,26 @@ class IosImageShareManager : ImageShareManager {
     ): Result<Unit> =
         withContext(Dispatchers.Main) {
             runCatching {
-                UIImageWriteToSavedPhotosAlbum(image.toUIImage(), null, null, null)
+                val uiImage = image.toUIImage()
+                requestPhotoAddPermission()
+                suspendCancellableCoroutine { continuation ->
+                    PHPhotoLibrary.sharedPhotoLibrary().performChanges(
+                        changeBlock = {
+                            PHAssetChangeRequest.creationRequestForAssetFromImage(uiImage)
+                        },
+                        completionHandler = { success, error ->
+                            if (continuation.isActive) {
+                                if (success && error == null) {
+                                    continuation.resume(Unit)
+                                } else {
+                                    continuation.resumeWithException(
+                                        IllegalStateException(error?.localizedDescription ?: "Image save failed"),
+                                    )
+                                }
+                            }
+                        },
+                    )
+                }
             }
         }
 
@@ -58,5 +85,25 @@ class IosImageShareManager : ImageShareManager {
                 NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
             }
         return UIImage.imageWithData(nsData) ?: error("UIImage creation failed")
+    }
+
+    private suspend fun requestPhotoAddPermission() {
+        val currentStatus = PHPhotoLibrary.authorizationStatusForAccessLevel(PHAccessLevelAddOnly)
+        val status =
+            if (currentStatus == PHAuthorizationStatusNotDetermined) {
+                suspendCancellableCoroutine { continuation ->
+                    PHPhotoLibrary.requestAuthorizationForAccessLevel(PHAccessLevelAddOnly) { newStatus ->
+                        if (continuation.isActive) {
+                            continuation.resume(newStatus)
+                        }
+                    }
+                }
+            } else {
+                currentStatus
+            }
+
+        if (status != PHAuthorizationStatusAuthorized && status != PHAuthorizationStatusLimited) {
+            throw PhotoLibraryPermissionDeniedException()
+        }
     }
 }


### PR DESCRIPTION
**[관련 이슈]**
- #422

**[작업한 내용]**
- iOS 이미지 저장 시 `PHPhotoLibrary.performChanges` completion 결과를 `Result`에 반영하도록 수정했습니다.
- iOS 사진 추가 권한이 미결정 상태이면 시스템 권한 요청을 수행하고, 거부 상태이면 설정 안내 다이얼로그를 표시하도록 처리했습니다.
- 사진 권한 설정 이동은 421 브랜치의 moko-permissions 구조에 맞춰 `PermissionsController.openAppSettings()`를 사용하도록 연결했습니다.

**[PR 포인트]**
- 이 PR은 `fix/421-request-storage-permission`을 base로 하는 stacked PR입니다.
- 421의 Android legacy 저장 권한 요청 구조는 유지하고, 422에서는 iOS add-only 사진 저장 권한과 저장 완료 callback 처리만 추가했습니다.
- 검증: `./gradlew :feature:balancegame:compileKotlinIosSimulatorArm64`, `./gradlew :feature:balancegame:compileAndroidMain`, `./gradlew :feature:balancegame:spotlessCheck`